### PR TITLE
fix: checking status instead of escapedStatus

### DIFF
--- a/backend/handle_tw.go
+++ b/backend/handle_tw.go
@@ -243,11 +243,11 @@ func ModifyTaskInTaskwarrior(uuid, description, project, priority, status, due, 
 		return fmt.Errorf("failed to edit task due: %v", err)
 	}
 
-	escapedStatus := fmt.Sprintf(`status:%s`, strings.ReplaceAll(status, `"`, `\"`))
-	if escapedStatus == "completed" {
+	// escapedStatus := fmt.Sprintf(`status:%s`, strings.ReplaceAll(status, `"`, `\"`))
+	if status == "completed" {
 		cmd = exec.Command("task", taskuuid, "done", "rc.confirmation=off")
 		cmd.Run()
-	} else if escapedStatus == "deleted" {
+	} else if status == "deleted" {
 		cmd = exec.Command("task", taskuuid, "delete", "rc.confirmation=off")
 		cmd.Run()
 	}


### PR DESCRIPTION
escapedStatus was being checked against 'completed' or 'deleted' but escapedStatus will always have 'status:' prepended.

Changed so that status will be used instead of escapedStatus

fixes: #52

created this PR to avoid the commit spams.
