### PR TITLE
fix: added checks before tasks can be submitted

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -175,6 +175,33 @@ export const Tasks = (props: Props) => {
     }
 
     async function handleAddTask(email: string, encryptionSecret: string, UUID: string, description: string, project: string, priority: string, due: string,) {
+        if(description.length===0) {
+            return toast.error('Description cannot be empty!', {
+                position: 'bottom-left',
+                autoClose: 3000,
+                hideProgressBar: false,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+            })
+        }
+        const date = new Date(due);
+        if(
+            isNaN(date.getTime()) ||
+            due !== date.toISOString().split('T')[0]
+        ){
+            return toast.error('Due date should be in the format YYYY-MM-DD!', {
+                position: 'bottom-left',
+                autoClose: 3000,
+                hideProgressBar: false,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+            })
+        }
+    
         if (handleDate(newTask.due)) {
             try {
                 const backendURL = url.backendURL + `add-task`;
@@ -190,7 +217,7 @@ export const Tasks = (props: Props) => {
                         due: due,
                     }),
                 });
-                if (response) {
+                if (response.ok) {
                     console.log('Task added successfully!');
                     toast.success('Task added successfully!', {
                         position: 'bottom-left',


### PR DESCRIPTION
Solved issue #61
Added checks for description length and valid date input. implemented error toasts for both of the cases.
- for checking valid description just verified if the description length is 0 `if(description.length===0)`
- for checking valid date used this:
```ts
if(
    isNaN(date.getTime()) ||
    due !== date.toISOString().split('T')[0]
)
```
attaching  a video for reference:

[Screencast from 2025-01-08 18-55-43.webm](https://github.com/user-attachments/assets/ae54070d-51a0-4f6c-993b-c545b55a7da7)
