### PR TITLE
Fixes #81: Modal now closes automatically after clicking "Yes" button

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -999,19 +999,21 @@ export const Tasks = (
                                   </span>
                                 </DialogTitle>
                                 <DialogFooter className="flex flex-row justify-center">
-                                  <Button
-                                    className="mr-5"
-                                    onClick={() =>
-                                      markTaskAsCompleted(
-                                        props.email,
-                                        props.encryptionSecret,
-                                        props.UUID,
-                                        task.uuid
-                                      )
-                                    }
-                                  >
-                                    Yes
-                                  </Button>
+                                  <DialogClose asChild>
+                                    <Button
+                                      className="mr-5"
+                                      onClick={() =>
+                                        markTaskAsCompleted(
+                                          props.email,
+                                          props.encryptionSecret,
+                                          props.UUID,
+                                          task.uuid
+                                        )
+                                      }
+                                    >
+                                      Yes
+                                    </Button>
+                                  </DialogClose>
                                   <DialogClose asChild>
                                     <Button variant={'destructive'}>No</Button>
                                   </DialogClose>
@@ -1041,19 +1043,21 @@ export const Tasks = (
                                   </span>
                                 </DialogTitle>
                                 <DialogFooter className="flex flex-row justify-center">
-                                  <Button
-                                    className="mr-5"
-                                    onClick={() =>
-                                      markTaskAsDeleted(
-                                        props.email,
-                                        props.encryptionSecret,
-                                        props.UUID,
-                                        task.uuid
-                                      )
-                                    }
-                                  >
-                                    Yes
-                                  </Button>
+                                  <DialogClose asChild>
+                                    <Button
+                                      className="mr-5"
+                                      onClick={() =>
+                                        markTaskAsDeleted(
+                                          props.email,
+                                          props.encryptionSecret,
+                                          props.UUID,
+                                          task.uuid
+                                        )
+                                      }
+                                    >
+                                      Yes
+                                    </Button>
+                                  </DialogClose>
                                   <DialogClose asChild>
                                     <Button variant={'destructive'}>No</Button>
                                   </DialogClose>


### PR DESCRIPTION
### **Description:**  
This PR resolves the issue where the modal did not close after clicking the "Yes" button. The button is now wrapped inside `<DialogClose>`, ensuring that the modal closes automatically upon clicking "Yes."  

### **Fixes:**  
- Wrapped the "Yes" button inside `<DialogClose>`, allowing automatic modal closure.  
- Ensured a smooth user experience without additional actions needed to close the modal.  

### **Changes Made:**  
- Updated modal component to use `<DialogClose>` around the "Yes" button.  
- Tested and confirmed that the modal now closes immediately when "Yes" is clicked.  

closes #81 
 
### **Testing:**  
- [x] Manually tested on different browsers/devices  
- [x] Verified no console errors on modal close  
- [x] Checked expected behavior across different interactions  

### **Impact & Rollback Plan:**  
- No breaking changes expected.  
- If issues arise, we can revert the `<DialogClose>` wrapper and re-evaluate the approach.  


