### PR TITLE
Fixes #86: GitHub icon navigation in Navbar

### DIFF
--- a/frontend/src/components/HomeComponents/Navbar/NavbarDesktop.tsx
+++ b/frontend/src/components/HomeComponents/Navbar/NavbarDesktop.tsx
@@ -17,6 +17,7 @@ import {
   RouteProps,
   Props,
 } from './navbar-utils';
+import { url } from '@/components/utils/URLs';
 
 export const NavbarDesktop = (
   props: Props & {
@@ -75,7 +76,9 @@ export const NavbarDesktop = (
             <Trash2 className="mr-2 h-4 w-4" />
             Delete all tasks
           </DropdownMenuItem>
-          <DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => window.open(url.githubRepoURL, '_blank')}
+          >
             <Github className="mr-2 h-4 w-4" />
             <span>GitHub</span>
           </DropdownMenuItem>


### PR DESCRIPTION
##  Summary
This PR fixes the issue where clicking the **GitHub button in the profile dropdown** did not trigger any action. Now, clicking the button correctly navigates to the CCSync **GitHub repository**

##  Changes Made
- Fixed the **onClick handler** for the GitHub dropdown menu item.
- Implemented **`window.open(url, "_blank")`** to redirect users to the GitHub repo.
- Ensured smooth navigation without breaking other dropdown functionalities.

## ✅ Fixes
Closes #86 

##  Steps to Test
1. Log in using Google credentials.
2. Click on the **profile avatar** in the top-right corner.
3. Click on the **GitHub button** in the dropdown.
4. It should **open the GitHub repository** in a new tab.

##  Expected Behavior
-  Clicking the GitHub icon now correctly **redirects to the repository**.
-  Works seamlessly with **no UI or functionality breakage**.
