### PR TITLE
feat(ui): add tag filtering to mobile bottom bar

### DIFF
--- a/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
+++ b/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
@@ -18,6 +18,8 @@ const BottomBar: React.FC<BottomBarProps> = ({
   setSelectedProject,
   status,
   setSelectedStatus,
+  tags,
+  setSelectedTag,
 }) => {
   const handleFilterChange = (value: string) => {
     if (!value) return;
@@ -26,6 +28,8 @@ const BottomBar: React.FC<BottomBarProps> = ({
       setSelectedProject(filterValue);
     } else if (type === 'status') {
       setSelectedStatus(filterValue);
+    } else if (type === 'tag') {
+      setSelectedTag(filterValue);
     }
   };
   return (
@@ -85,6 +89,19 @@ const BottomBar: React.FC<BottomBarProps> = ({
               {status.map((s) => (
                 <SelectItem key={s} value={`status:${s}`}>
                   {s.charAt(0).toUpperCase() + s.slice(1)}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+
+            {/* Group for Tags */}
+            <SelectGroup>
+              <SelectLabel className="px-2 py-1.5 text-sm font-semibold text-muted-foreground">
+                Tags
+              </SelectLabel>
+              <SelectItem value="tag:all">All Tags</SelectItem>
+              {tags.map((tag) => (
+                <SelectItem key={tag} value={`tag:${tag}`}>
+                  {tag}
                 </SelectItem>
               ))}
             </SelectGroup>

--- a/frontend/src/components/HomeComponents/BottomBar/__tests__/BottomBar.test.tsx
+++ b/frontend/src/components/HomeComponents/BottomBar/__tests__/BottomBar.test.tsx
@@ -4,8 +4,10 @@ import BottomBar from '../BottomBar';
 describe('BottomBar Component', () => {
   const mockSetSelectedProject = jest.fn();
   const mockSetSelectedStatus = jest.fn();
+  const mockSetSelectedTag = jest.fn();
   const projects = ['Project A', 'Project B'];
   const status = ['Status A', 'Status B'];
+  const tags = ['bug', 'feature'];
 
   test('renders BottomBar component', () => {
     render(
@@ -14,6 +16,8 @@ describe('BottomBar Component', () => {
         setSelectedProject={mockSetSelectedProject}
         status={status}
         setSelectedStatus={mockSetSelectedStatus}
+        tags={tags}
+        setSelectedTag={mockSetSelectedTag}
       />
     );
 

--- a/frontend/src/components/HomeComponents/BottomBar/__tests__/bottom-bar-utils.test.ts
+++ b/frontend/src/components/HomeComponents/BottomBar/__tests__/bottom-bar-utils.test.ts
@@ -9,17 +9,21 @@ describe('RouteProps interface', () => {
 });
 
 describe('BottomBarProps interface', () => {
-  it('should have project and status properties', () => {
+  it('should have project, status, and tag properties', () => {
     const example: BottomBarProps = {
       projects: [''],
       setSelectedProject: jest.fn(),
       status: [''],
       setSelectedStatus: jest.fn(),
+      tags: [''],
+      setSelectedTag: jest.fn(),
     };
     expect(example).toHaveProperty('projects');
     expect(example).toHaveProperty('setSelectedProject');
     expect(example).toHaveProperty('status');
     expect(example).toHaveProperty('setSelectedStatus');
+    expect(example).toHaveProperty('tags');
+    expect(example).toHaveProperty('setSelectedTag');
   });
 });
 

--- a/frontend/src/components/HomeComponents/BottomBar/bottom-bar-utils.ts
+++ b/frontend/src/components/HomeComponents/BottomBar/bottom-bar-utils.ts
@@ -10,6 +10,8 @@ export interface BottomBarProps {
   setSelectedProject: Dispatch<SetStateAction<string>>;
   status: string[];
   setSelectedStatus: Dispatch<SetStateAction<string>>;
+  tags: string[];
+  setSelectedTag: Dispatch<SetStateAction<string>>;
 }
 
 export const routeList: RouteProps[] = [

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -416,6 +416,8 @@ export const Tasks = (
         setSelectedProject={setSelectedProject}
         status={['pending', 'completed', 'deleted']}
         setSelectedStatus={setSelectedStatus}
+        tags={uniqueTags}
+        setSelectedTag={setSelectedTag}
       />
       <h2
         data-testid="tasks"


### PR DESCRIPTION
This commit extends the mobile bottom bar's unified filter functionality to include tag-based filtering, achieving feature parity with the desktop interface as requested in the issue.

- Updated `BottomBarProps` interface to accept `tags` and `setSelectedTag`.
- Modified `BottomBar.tsx` to render the 'Tags' group within the single filter dropdown.
- Updated `handleFilterChange` to process 'tag:' prefixed values.
- Passed the required props (`uniqueTags`, `setSelectedTag`) from `Tasks.tsx`.
- Updated Jest tests for `BottomBar` and its utils to reflect the new props and ensure full coverage.

### Description

<!-- Provide a brief description of the changes made in this PR -->

- Fixes #130

### Checklist

- [X] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [X] Ran `npm test` (for JS/TS testing)
- [X] Added unit tests, if applicable
- [X] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

- **Screenshots**

<img width="397" height="643" alt="image" src="https://github.com/user-attachments/assets/6377e7ab-237f-4752-9224-7409a3360882" />


<!-- Any additional info, screenshots, or context -->
