### PR TITLE
feat: Enable multi-arch Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           context: ./frontend
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/ccextractor/frontend:latest
             ghcr.io/ccextractor/frontend:${{ github.sha }}
@@ -66,6 +67,7 @@ jobs:
         with:
           context: ./backend
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/ccextractor/backend:latest
             ghcr.io/ccextractor/backend:${{ github.sha }}


### PR DESCRIPTION
### Description

This PR updates the GitHub Actions workflow to enable multi-arch Docker builds.

Currently, the Docker images published to GHCR only support the `linux/amd64` architecture. This prevents native execution on `arm64` systems like Apple Silicon Macs, forcing users to rely on slower emulation.

This change adds the `linux/arm64` platform to the build process, creating a multi-arch image that runs natively on both `amd64` and `arm64` systems.

- Fixes: #136

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [ ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ ] Verified all tests pass
- [ ] Updated documentation, if needed

### Verification

I successfully tested this change in my fork.

![Successful multi-arch build](https://github.com/user-attachments/assets/28a56318-b7b7-4907-947f-3874cdabffcb)