### PR TITLE
feat(filters): implement additive multi-select for filters

### DIFF
--- a/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
+++ b/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
@@ -15,21 +15,21 @@ import { Icons } from '@/components/icons';
 
 const BottomBar: React.FC<BottomBarProps> = ({
   projects,
-  setSelectedProject,
+  onProjectSelect,
   status,
-  setSelectedStatus,
+  onStatusSelect,
   tags,
-  setSelectedTag,
+  onTagSelect,
 }) => {
   const handleFilterChange = (value: string) => {
     if (!value) return;
     const [type, filterValue] = value.split(':');
     if (type === 'project') {
-      setSelectedProject(filterValue);
+      onProjectSelect(filterValue);
     } else if (type === 'status') {
-      setSelectedStatus(filterValue);
+      onStatusSelect(filterValue);
     } else if (type === 'tag') {
-      setSelectedTag(filterValue);
+      onTagSelect(filterValue);
     }
   };
   return (

--- a/frontend/src/components/HomeComponents/BottomBar/__tests__/BottomBar.test.tsx
+++ b/frontend/src/components/HomeComponents/BottomBar/__tests__/BottomBar.test.tsx
@@ -2,28 +2,27 @@ import { render, screen } from '@testing-library/react';
 import BottomBar from '../BottomBar';
 
 describe('BottomBar Component', () => {
-  const mockSetSelectedProject = jest.fn();
-  const mockSetSelectedStatus = jest.fn();
-  const mockSetSelectedTag = jest.fn();
+  const mockOnProjectSelect = jest.fn();
+  const mockOnStatusSelect = jest.fn();
+  const mockOnTagSelect = jest.fn();
   const projects = ['Project A', 'Project B'];
-  const status = ['Status A', 'Status B'];
+  const status = ['pending', 'completed'];
   const tags = ['bug', 'feature'];
 
   test('renders BottomBar component', () => {
     render(
       <BottomBar
         projects={projects}
-        setSelectedProject={mockSetSelectedProject}
+        onProjectSelect={mockOnProjectSelect}
         status={status}
-        setSelectedStatus={mockSetSelectedStatus}
+        onStatusSelect={mockOnStatusSelect}
         tags={tags}
-        setSelectedTag={mockSetSelectedTag}
+        onTagSelect={mockOnTagSelect}
       />
     );
 
     const homeLink = screen.getByRole('link', { name: /home/i });
     const tasksLink = screen.getByRole('link', { name: /tasks/i });
-
     expect(homeLink).toHaveAttribute('href', '#');
     expect(tasksLink).toHaveAttribute('href', '#tasks');
 

--- a/frontend/src/components/HomeComponents/BottomBar/__tests__/bottom-bar-utils.test.ts
+++ b/frontend/src/components/HomeComponents/BottomBar/__tests__/bottom-bar-utils.test.ts
@@ -9,21 +9,21 @@ describe('RouteProps interface', () => {
 });
 
 describe('BottomBarProps interface', () => {
-  it('should have project, status, and tag properties', () => {
+  it('should have properties for projects, status, tags, and their handlers', () => {
     const example: BottomBarProps = {
       projects: [''],
-      setSelectedProject: jest.fn(),
+      onProjectSelect: jest.fn(),
       status: [''],
-      setSelectedStatus: jest.fn(),
+      onStatusSelect: jest.fn(),
       tags: [''],
-      setSelectedTag: jest.fn(),
+      onTagSelect: jest.fn(),
     };
     expect(example).toHaveProperty('projects');
-    expect(example).toHaveProperty('setSelectedProject');
+    expect(example).toHaveProperty('onProjectSelect');
     expect(example).toHaveProperty('status');
-    expect(example).toHaveProperty('setSelectedStatus');
+    expect(example).toHaveProperty('onStatusSelect');
     expect(example).toHaveProperty('tags');
-    expect(example).toHaveProperty('setSelectedTag');
+    expect(example).toHaveProperty('onTagSelect');
   });
 });
 

--- a/frontend/src/components/HomeComponents/BottomBar/bottom-bar-utils.ts
+++ b/frontend/src/components/HomeComponents/BottomBar/bottom-bar-utils.ts
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
-
 export interface RouteProps {
   href: string;
   label: string;
@@ -7,11 +5,11 @@ export interface RouteProps {
 
 export interface BottomBarProps {
   projects: string[];
-  setSelectedProject: Dispatch<SetStateAction<string>>;
+  onProjectSelect: (project: string) => void;
   status: string[];
-  setSelectedStatus: Dispatch<SetStateAction<string>>;
+  onStatusSelect: (status: string) => void;
   tags: string[];
-  setSelectedTag: Dispatch<SetStateAction<string>>;
+  onTagSelect: (tag: string) => void;
 }
 
 export const routeList: RouteProps[] = [

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -31,6 +31,10 @@ jest.mock('../tasks-utils', () => {
   };
 });
 
+jest.mock('../../BottomBar/BottomBar', () => {
+  return jest.fn(() => <div>Mocked BottomBar</div>);
+});
+
 global.fetch = jest.fn().mockResolvedValue({ ok: true });
 
 describe('Tasks Component', () => {


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes made in this PR -->

- Refactors filter state from `string` to `string[]` to support multi-select.
- Updates handlers to be additive (add to array) instead of replacing.
- Keeps existing `<Select>` UI for desktop and mobile as per feedback.
- Adds a display area for active filters as removable `<Badge>` components.
- Updates all related tests to match new props.

**Fixes:** #131

---

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

---

### Additional Notes

<!-- Any additional info, screenshots, or context -->

<img width="1396" height="518" alt="Screenshot 2025-11-05 at 4 53 59 AM" src="https://github.com/user-attachments/assets/2c83f4a0-ebbc-4cb3-b894-331c0f017785" />

<img width="1353" height="471" alt="Screenshot 2025-11-05 at 4 55 06 AM" src="https://github.com/user-attachments/assets/0a4f811e-1824-4eea-aaac-4bc75b6c12ca" />
<img width="400" height="690" alt="Screenshot 2025-11-05 at 4 56 00 AM" src="https://github.com/user-attachments/assets/308d37ab-def9-4369-a015-b338ba0abfce" />
<img width="400" height="647" alt="Screenshot 2025-11-05 at 4 57 40 AM" src="https://github.com/user-attachments/assets/2eba80c7-a00d-45c2-942f-93885581a2a0" />


