### PR TITLE
feat(frontend): add tooltips for better UX

### DIFF
--- a/frontend/src/components/HomeComponents/SetupGuide/CopyableCode.tsx
+++ b/frontend/src/components/HomeComponents/SetupGuide/CopyableCode.tsx
@@ -51,7 +51,12 @@ export const CopyableCode = ({
         </code>
       </div>
       {isSensitive && (
-        <Tooltip title={showSensitive ? 'Hide sensitive value' : 'Show sensitive value'} position='bottom'>
+        <Tooltip
+          title={
+            showSensitive ? 'Hide sensitive value' : 'Show sensitive value'
+          }
+          position="bottom"
+        >
           <button
             onClick={() => setShowSensitive(!showSensitive)}
             className="bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 sm:p-4 rounded flex-shrink-0"
@@ -68,7 +73,7 @@ export const CopyableCode = ({
         </Tooltip>
       )}
       <CopyToClipboard text={copyText} onCopy={() => handleCopy(copyText)}>
-        <Tooltip title="Copy to clipboard" position='bottom'>
+        <Tooltip title="Copy to clipboard" position="bottom">
           <button
             className="bg-blue-500 hover:bg-blue-600 active:bg-blue-800 text-white font-bold p-3 sm:p-4 rounded flex-shrink-0"
             aria-label="Copy to clipboard"

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,21 +1,25 @@
 interface TooltipProps {
   children: React.ReactNode;
   title: string;
-  position?: "top" | "bottom";
+  position?: 'top' | 'bottom';
 }
 
 const Tooltip = ({ children, title, position }: TooltipProps) => {
-  const topClasses = "after:-translate-x-1/2 after:left-1/2 group-hover:bottom-full group-hover:opacity-100 -translate-y-2.5 bottom-1/2 group-focus:opacity-100 group-focus:bottom-full";
-  const bottomClasses = "after:top-0 after:-translate-y-1/2 after:left-1/2 after:-translate-x-1/2 top-1/2 group-hover:top-full group-hover:opacity-100 translate-y-2.5 group-focus:opacity-100 group-focus:top-full";
+  const topClasses =
+    'after:-translate-x-1/2 after:left-1/2 group-hover:bottom-full group-hover:opacity-100 -translate-y-2.5 bottom-1/2 group-focus:opacity-100 group-focus:bottom-full';
+  const bottomClasses =
+    'after:top-0 after:-translate-y-1/2 after:left-1/2 after:-translate-x-1/2 top-1/2 group-hover:top-full group-hover:opacity-100 translate-y-2.5 group-focus:opacity-100 group-focus:top-full';
 
   return (
     <div className="relative group" tabIndex={0}>
       {children}
-      <span className={`pointer-events-none z-10 bg-stone-700 opacity-0 text-white px-2 text-nowrap py-1 text-xs absolute left-1/2 -translate-x-1/2 rounded-sm transition-['transform,opacity'] shadow-slate-900/60 duration-200 after:size-2 after:rotate-45 after:block after:bg-stone-700 after:absolute shadow-md ${position === "top" ? topClasses : bottomClasses}`}>
+      <span
+        className={`pointer-events-none z-10 bg-stone-700 opacity-0 text-white px-2 text-nowrap py-1 text-xs absolute left-1/2 -translate-x-1/2 rounded-sm transition-['transform,opacity'] shadow-slate-900/60 duration-200 after:size-2 after:rotate-45 after:block after:bg-stone-700 after:absolute shadow-md ${position === 'top' ? topClasses : bottomClasses}`}
+      >
         {title}
       </span>
     </div>
-  )
-}
+  );
+};
 
-export default Tooltip
+export default Tooltip;


### PR DESCRIPTION
### Description

Added tooltips for copy buttons and hide buttons

- Fixes: #108

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing; note: some IndexedDB tests fail in Node environment, but app works in browser)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass in browser
- [ ] Updated documentation, if needed

### Additional Notes

- Tooltip uses TailwindCSS classes for transition, positioning, and arrow display.
- Tested locally in browser.

And i dont wanted to change, 
   - backend/go.mod
   - frontend/package-lock.json
   
 It automatically changed when i setup project locally.
   
