### PR TITLE
feat(dev): Add tmux setup script for local development

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,76 @@
+# CCSync Development Script
+
+This directory contains a script to automate the local development setup for CCSync.
+
+The `setup.sh` script starts all three services (backend, frontend, and sync server) in a single `tmux` session, each in its own pane.
+
+## Prerequisites
+
+Before running the script, you **must** have the following installed and running:
+
+- [**Go**](https://go.dev/doc/install) (latest version)
+- [**Node.js**](https://nodejs.org/en) (which includes `npm`)
+- [**Docker**](https://www.docker.com/get-started) (and it must be running)
+- [**Tmux**](https://github.com/tmux/tmux/wiki)
+
+---
+
+## 1. Environment Setup
+
+This script **does not** create your `.env` files. You must create them first.
+
+Copy your keys and secrets into the following two files.
+
+#### `backend/.env`
+
+(Place this file in the `backend/` directory)
+
+```
+CLIENT_ID="your_google_client_id"
+CLIENT_SEC="your_google_client_secret"
+REDIRECT_URL_DEV="http://localhost:8000/auth/callback"
+SESSION_KEY="your_secret_key"
+FRONTEND_ORIGIN_DEV="http://localhost:5173"
+CONTAINER_ORIGIN="http://localhost:8080/"
+```
+
+#### `frontend/.env`
+
+(Place this file in the `frontend/` directory)
+
+```
+VITE_BACKEND_URL="http://localhost:8000/"
+VITE_FRONTEND_URL="http://localhost:5173"
+VITE_CONTAINER_ORIGIN="http://localhost:8080/"
+```
+
+> **Note:** For help generating Google OAuth keys (`CLIENT_ID`, `CLIENT_SEC`), refer to the **main documentation** in the root directory.
+
+---
+
+## 2. How to Run
+
+1.  From the **project's root directory**, make the script executable (you only need to do this once):
+
+    ```bash
+    chmod +x ./development/setup.sh
+    ```
+
+2.  Run the script from the **project's root directory**:
+    ```bash
+    ./development/setup.sh
+    ```
+
+This will create and attach you to a `tmux` session named `ccsync`. You will see all three servers start up, one in each pane.
+
+> To detach from the tmux session (keep it running in the background), press **Ctrl + b**, then **d**.  
+> You can reattach anytime using:
+>
+> ```bash
+> tmux attach -t ccsync
+> ```
+
+### Troubleshooting
+
+- **Permissions Error (Backend):** The script runs `go run .` without `sudo`. If the backend fails with a "permission denied" error, it's likely because it cannot write to your `taskrc` file. Ensure your current user has write permissions for `~/.taskrc`.
+- **Docker Error:** Make sure Docker is running _before_ you execute the script.

--- a/development/setup.sh
+++ b/development/setup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Starts backend, frontend, and syncserver in a tmux session with 3 panes.
+# Usage: run from project root -> ./development/setup.sh
+
+
+SESSION="ccsync"
+
+# --- Safety checks ---
+
+# Check if tmux is installed
+if ! command -v tmux &> /dev/null; then
+    echo "Error: tmux is not installed."
+    echo "Please install it to use this script (e.g., 'brew install tmux' or 'apt-get install tmux')."
+    exit 1
+fi
+
+# Check if Docker is running
+if ! docker info &> /dev/null; then
+    echo "Error: Docker is not running."
+    echo "Please start Docker to run the syncserver."
+    exit 1
+fi
+
+# --- Main Script ---
+
+# Check if the session already exists
+tmux has-session -t $SESSION 2>/dev/null
+
+if [ $? != 0 ]; then
+    # Session does not exist, so let's create it.
+    echo "Creating new tmux session '$SESSION'..."
+
+    # Create a new detached session and start backend
+    tmux new-session -d -s $SESSION -n "servers" "cd backend && go run ."
+
+    # Split horizontally and run frontend
+    tmux split-window -h -t $SESSION "cd frontend && npm run dev"
+
+    # Split vertically and run syncserver
+    tmux split-window -v -t $SESSION:0.1 "docker-compose up syncserver"
+
+    # Set a 3-pane layout (T-shape)
+    tmux select-layout -t $SESSION "tiled"
+    
+    echo "Session '$SESSION' created."
+else
+    echo "Session '$SESSION' already exists."
+fi
+
+# Print final info before attaching
+echo "All services started inside tmux session: $SESSION"
+echo "To detach: press Ctrl+b then d"
+
+# Attach to the session
+echo "Attaching to session..."
+tmux attach -t $SESSION


### PR DESCRIPTION
Creates a new 'development/setup.sh' script to automatically start the backend, frontend, and sync server in a 3-pane tmux session.

This solves the problem of needing to run multiple servers in separate terminals, simplifying the setup for new contributors.

Also adds a 'development/README.md' explaining prerequisites and usage.

### Description

<!-- Provide a brief description of the changes made in this PR -->

- Fixes: #155 

### Checklist

- [ ] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [ ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ ] Verified all tests pass
- [x] Updated documentation, if needed

### Additional Notes

<!-- Any additional info, screenshots, or context -->
