### PR TITLE
Add end field to Add Task feature

### DIFF
--- a/backend/controllers/add_task.go
+++ b/backend/controllers/add_task.go
@@ -47,6 +47,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 		priority := requestBody.Priority
 		dueDate := requestBody.DueDate
 		start := requestBody.Start
+		end := requestBody.End
 		tags := requestBody.Tags
 
 		if description == "" {
@@ -63,7 +64,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Add Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Adding task: %s", description), uuid, "Add Task")
-				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start, tags)
+				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start, end, tags)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to add task: %v", err), uuid, "Add Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -10,6 +10,7 @@ type AddTaskRequestBody struct {
 	Priority         string   `json:"priority"`
 	DueDate          string   `json:"due"`
 	Start            string   `json:"start"`
+	End              string   `json:"end"`
 	Tags             []string `json:"tags"`
 }
 type ModifyTaskRequestBody struct {

--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -8,7 +8,7 @@ import (
 )
 
 // add task to the user's tw client
-func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start string, tags []string) error {
+func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start, end string, tags []string) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -40,6 +40,9 @@ func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, p
 	}
 	if start != "" {
 		cmdArgs = append(cmdArgs, "scheduled:"+start)
+	}
+	if end != "" {
+		cmdArgs = append(cmdArgs, "end:"+end)
 	}
 	// Add tags to the task
 	if len(tags) > 0 {

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -100,6 +100,7 @@ export const Tasks = (
     project: '',
     due: '',
     start: '',
+    end: '',
     tags: [] as string[],
   });
   const [isAddTaskOpen, setIsAddTaskOpen] = useState(false);
@@ -282,6 +283,7 @@ export const Tasks = (
     priority: string,
     due: string,
     start: string,
+    end: string,
     tags: string[]
   ) {
     if (handleDate(newTask.due)) {
@@ -295,6 +297,7 @@ export const Tasks = (
           priority,
           due,
           start,
+          end,
           tags,
           backendURL: url.backendURL,
         });
@@ -306,6 +309,7 @@ export const Tasks = (
           project: '',
           due: '',
           start: '',
+          end: '',
           tags: [],
         });
         setIsAddTaskOpen(false);
@@ -766,6 +770,29 @@ export const Tasks = (
                               </div>
                             </div>
                             <div className="grid grid-cols-4 items-center gap-4">
+                              <Label htmlFor="end" className="text-right">
+                                End
+                              </Label>
+                              <div className="col-span-3">
+                                <DatePicker
+                                  date={
+                                    newTask.end
+                                      ? new Date(newTask.end)
+                                      : undefined
+                                  }
+                                  onDateChange={(date) => {
+                                    setNewTask({
+                                      ...newTask,
+                                      end: date
+                                        ? format(date, 'yyyy-MM-dd')
+                                        : '',
+                                    });
+                                  }}
+                                  placeholder="Select an end date"
+                                />
+                              </div>
+                            </div>
+                            <div className="grid grid-cols-4 items-center gap-4">
                               <Label
                                 htmlFor="description"
                                 className="text-right"
@@ -825,6 +852,7 @@ export const Tasks = (
                                   newTask.priority,
                                   newTask.due,
                                   newTask.start,
+                                  newTask.end,
                                   newTask.tags
                                 )
                               }
@@ -1575,6 +1603,67 @@ export const Tasks = (
                                 />
                               </div>
                             </div>
+                            <div className="grid grid-cols-4 items-center gap-4">
+                              <Label htmlFor="end" className="text-right">
+                                End
+                              </Label>
+                              <div className="col-span-3">
+                                <DatePicker
+                                  date={
+                                    newTask.end
+                                      ? new Date(newTask.end)
+                                      : undefined
+                                  }
+                                  onDateChange={(date) => {
+                                    setNewTask({
+                                      ...newTask,
+                                      end: date
+                                        ? format(date, 'yyyy-MM-dd')
+                                        : '',
+                                    });
+                                  }}
+                                  placeholder="Select an end date"
+                                />
+                              </div>
+                            </div>
+                            <div className="grid grid-cols-4 items-center gap-4">
+                              <Label
+                                htmlFor="description"
+                                className="text-right"
+                              >
+                                Tags
+                              </Label>
+                              <Input
+                                id="tags"
+                                name="tags"
+                                placeholder="Add a tag"
+                                value={tagInput}
+                                onChange={(e) => setTagInput(e.target.value)}
+                                onKeyDown={(e) =>
+                                  e.key === 'Enter' && handleAddTag()
+                                } // Allow adding tag on pressing Enter
+                                className="col-span-3"
+                              />
+                            </div>
+
+                            <div className="mt-2">
+                              {newTask.tags.length > 0 && (
+                                <div className="flex flex-wrap gap-2">
+                                  {newTask.tags.map((tag, index) => (
+                                    <Badge key={index}>
+                                      <span>{tag}</span>
+                                      <button
+                                        type="button"
+                                        className="ml-2 text-red-500"
+                                        onClick={() => handleRemoveTag(tag)}
+                                      >
+                                        ✖
+                                      </button>
+                                    </Badge>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
                           </div>
                           <DialogFooter>
                             <Button
@@ -1596,6 +1685,7 @@ export const Tasks = (
                                   newTask.priority,
                                   newTask.due,
                                   newTask.start,
+                                  newTask.end,
                                   newTask.tags
                                 )
                               }

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -43,6 +43,7 @@ export const addTaskToBackend = async ({
   priority,
   due,
   start,
+  end,
   tags,
   backendURL,
 }: {
@@ -54,6 +55,7 @@ export const addTaskToBackend = async ({
   priority: string;
   due: string;
   start: string;
+  end: string;
   tags: string[];
   backendURL: string;
 }) => {
@@ -68,6 +70,7 @@ export const addTaskToBackend = async ({
       priority,
       due,
       start,
+      end,
       tags,
     }),
     headers: {


### PR DESCRIPTION
### Description

This PR adds support for the **end** field when creating tasks through the UI, allowing users to specify an end date for their tasks directly from the Add Task dialog.

This is part of the ongoing effort to make more task fields editable through the frontend interface, as outlined in the original issue.

- Fixes: #(issue_number_for_end_field)
- Related to: #(the_main_issue_number_about_making_fields_editable)
### Changes Made

**Frontend Changes:**
- Added `end` field to `newTask` state in Tasks component
- Added End DatePicker input to both Add Task dialogs (main view and empty state view)
- Updated `handleAddTask` function to accept and pass `end` parameter
- Updated `addTaskToBackend` API function to send `end` field to backend
- Reset `end` field properly when form is cleared

**Backend Changes:**
- Added `End` field to `AddTaskRequestBody` model
- Updated `AddTaskHandler` controller to extract and process `end` field
- Updated `AddTaskToTaskwarrior` function signature to accept `end` parameter
- Added `end:` attribute to taskwarrior command when `end` value is provided
