### PR TITLE
feat:overdue filter implemented

### DIFF
--- a/backend/utils/tw/export_tasks.go
+++ b/backend/utils/tw/export_tasks.go
@@ -5,6 +5,7 @@ import (
 	"ccsync_backend/utils"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // export the tasks so as to add them to DB
@@ -18,6 +19,27 @@ func ExportTasks(tempDir string) ([]models.Task, error) {
 	var tasks []models.Task
 	if err := json.Unmarshal(output, &tasks); err != nil {
 		return nil, fmt.Errorf("error parsing tasks: %v", err)
+	}
+
+	now := time.Now()
+	for i := range tasks {
+		if tasks[i].Status != "pending" || tasks[i].Due == "" {
+			continue
+		}
+
+		// Taskwarrior uses timestamps like 20060102T150405Z
+		dueTime, err := time.Parse("20060102T150405Z", tasks[i].Due)
+		if err != nil {
+			// Fallback to RFC3339
+			dueTime, err = time.Parse(time.RFC3339, tasks[i].Due)
+			if err != nil {
+				continue
+			}
+		}
+
+		if dueTime.Before(now) {
+			tasks[i].Status = "overdue"
+		}
 	}
 
 	return tasks, nil

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -89,7 +89,7 @@ export const Tasks = (
   const [selectedProjects, setSelectedProjects] = useState<string[]>([]);
   const [tempTasks, setTempTasks] = useState<Task[]>([]);
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
-  const status = ['pending', 'completed', 'deleted'];
+  const status = ['pending', 'completed', 'deleted', 'overdue'];
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [idSortOrder, setIdSortOrder] = useState<'asc' | 'desc'>('asc');
@@ -559,7 +559,7 @@ export const Tasks = (
         projects={uniqueProjects}
         selectedProjects={selectedProjects}
         setSelectedProject={setSelectedProjects}
-        status={['pending', 'completed', 'deleted']}
+        status={['pending', 'completed', 'deleted', 'overdue']}
         selectedStatuses={selectedStatuses}
         setSelectedStatus={setSelectedStatuses}
         selectedTags={selectedTags}
@@ -931,12 +931,19 @@ export const Tasks = (
                                           ? 'destructive'
                                           : 'default'
                                     }
+                                    className={
+                                      task.status === 'overdue'
+                                        ? 'bg-orange-500 border-transparent'
+                                        : undefined
+                                    }
                                   >
-                                    {task.status === 'completed'
-                                      ? 'C'
-                                      : task.status === 'deleted'
-                                        ? 'D'
-                                        : 'P'}
+                                    {task.status === 'overdue'
+                                      ? 'O'
+                                      : task.status === 'completed'
+                                        ? 'C'
+                                        : task.status === 'deleted'
+                                          ? 'D'
+                                          : 'P'}
                                   </Badge>
                                 </TableCell>
                               </TableRow>


### PR DESCRIPTION
### Description

- Added another filter 'overdue' alongside the existing 'pending', 'completed', 'deleted' filters.
- Implemented the filter both in backend and frontend.
- The colour(background) of the badge is orange.

- Fixes: #186

### Checklist

- [ x ] Ran `npx prettier --write .` (for formatting)
- [ x ] Ran `gofmt -w .` (for Go backend)
- [ x ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ x ] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
https://github.com/user-attachments/assets/177c9487-955e-40a0-980c-ccc828a77c3e


