### PR TITLE
fixed sorting-function error

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -475,7 +475,7 @@ export const Tasks = (
     }
 
     // Sort + set
-    setTempTasks(sortTasksById(filteredTasks, 'desc'));
+    setTempTasks(filteredTasks);
   }, [selectedProjects, selectedTags, selectedStatuses, tasks]);
 
   const handleEditTagsClick = (task: Task) => {


### PR DESCRIPTION
### Description

This PR resolves an issue where sorting by status or ID stopped working whenever any filters (tags, projects, or status) were applied.
The filtering useEffect was always overwriting tempTasks with a fixed ID-sorted list, causing the user’s selected sort order to be lost.

### What Was Happening
-Sorting worked correctly at first.
-After applying any filter, the filter useEffect would run.
-This effect reset tempTasks using sortTasksById(filteredTasks, 'desc'), ignoring the selected sort order.
-As a result, sorting became unresponsive when filters were active.

### What This PR Changes
-Removed the forced sorting inside the filtering useEffect.
-Filtering now only filters the tasks and does not override the user’s sort order.

Sorting by ID and Status now works correctly even after applying:
-Tag filters
-Project filters
-Status filters

### - Fixes: #185

After fix
[Screencast from 17-11-25 08:28:44 PM IST.webm](https://github.com/user-attachments/assets/d67feba5-7a31-46b2-953b-45d82c50e961)

