### PR TITLE
feat: make entry field editable

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -47,6 +47,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 		tags := requestBody.Tags
 		project := requestBody.Project
 		start := requestBody.Start
+		entry := requestBody.Entry
 
 		if taskID == "" {
 			http.Error(w, "taskID is required", http.StatusBadRequest)
@@ -58,7 +59,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Edit Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Editing task ID: %s", taskID), uuid, "Edit Task")
-				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start)
+				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to edit task ID %s: %v", taskID, err), uuid, "Edit Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -32,6 +32,7 @@ type EditTaskRequestBody struct {
 	Tags             []string `json:"tags"`
 	Project          string   `json:"project"`
 	Start            string   `json:"start"`
+	Entry            string   `json:"entry"`
 }
 type CompleteTaskRequestBody struct {
 	Email            string `json:"email"`

--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string) error {
+func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -67,6 +67,13 @@ func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID st
 	if start != "" {
 		if err := utils.ExecCommand("task", taskID, "modify", "start:"+start); err != nil {
 			return fmt.Errorf("failed to set start date %s: %v", start, err)
+		}
+	}
+
+	// Handle entry date
+	if entry != "" {
+		if err := utils.ExecCommand("task", taskID, "modify", "entry:"+entry); err != nil {
+			return fmt.Errorf("failed to set entry date %s: %v", entry, err)
 		}
 	}
 

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -23,7 +23,7 @@ func TestSyncTaskwarrior(t *testing.T) {
 }
 
 func TestEditTaskInATaskwarrior(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior() failed: %v", err)
 	} else {
@@ -68,7 +68,7 @@ func TestAddTaskWithTags(t *testing.T) {
 }
 
 func TestEditTaskWithTagAddition(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag addition failed: %v", err)
 	} else {
@@ -77,7 +77,7 @@ func TestEditTaskWithTagAddition(t *testing.T) {
 }
 
 func TestEditTaskWithTagRemoval(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag removal failed: %v", err)
 	} else {
@@ -86,7 +86,7 @@ func TestEditTaskWithTagRemoval(t *testing.T) {
 }
 
 func TestEditTaskWithMixedTagOperations(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with mixed tag operations failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -120,6 +120,8 @@ export const Tasks = (
   );
   const [isEditingStartDate, setIsEditingStartDate] = useState(false);
   const [editedStartDate, setEditedStartDate] = useState('');
+  const [isEditingEntryDate, setIsEditingEntryDate] = useState(false);
+  const [editedEntryDate, setEditedEntryDate] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [lastSyncTime, setLastSyncTime] = useState<number | null>(null);
 
@@ -321,7 +323,8 @@ export const Tasks = (
     tags: string[],
     taskID: string,
     project: string,
-    start: string
+    start: string,
+    entry: string
   ) {
     try {
       await editTaskOnBackend({
@@ -334,6 +337,7 @@ export const Tasks = (
         backendURL: url.backendURL,
         project,
         start,
+        entry,
       });
 
       console.log('Task edited successfully!');
@@ -377,7 +381,8 @@ export const Tasks = (
       task.tags,
       task.id.toString(),
       task.project,
-      task.start
+      task.start,
+      task.entry || ''
     );
     setIsEditing(false);
   };
@@ -392,7 +397,8 @@ export const Tasks = (
       task.tags,
       task.id.toString(),
       task.project,
-      task.start
+      task.start,
+      task.entry || ''
     );
     setIsEditingProject(false);
   };
@@ -408,10 +414,29 @@ export const Tasks = (
       task.tags,
       task.id.toString(),
       task.project,
-      task.start
+      task.start,
+      task.entry || ''
     );
 
     setIsEditingStartDate(false);
+  };
+
+  const handleEntryDateSaveClick = (task: Task) => {
+    task.entry = editedEntryDate;
+
+    handleEditTaskOnBackend(
+      props.email,
+      props.encryptionSecret,
+      props.UUID,
+      task.description,
+      task.tags,
+      task.id.toString(),
+      task.project,
+      task.start,
+      task.entry
+    );
+
+    setIsEditingEntryDate(false);
   };
 
   const handleCancelClick = () => {
@@ -427,6 +452,10 @@ export const Tasks = (
       setEditedTags([]);
       setIsEditingPriority(false);
       setEditedPriority('NONE');
+      setIsEditingStartDate(false);
+      setEditedStartDate('');
+      setIsEditingEntryDate(false);
+      setEditedEntryDate('');
     } else {
       setSelectedTask(task);
       setEditedDescription(task?.description || '');
@@ -499,7 +528,8 @@ export const Tasks = (
       finalTags,
       task.id.toString(),
       task.project,
-      task.start
+      task.start,
+      task.entry || ''
     );
 
     setIsEditingTags(false); // Exit editing mode
@@ -1333,6 +1363,98 @@ export const Tasks = (
                                                 <PencilIcon className="h-4 w-4 text-gray-500" />
                                               </Button>
                                             </div>
+                                          )}
+                                        </TableCell>
+                                      </TableRow>
+                                      <TableRow>
+                                        <TableCell>Entry:</TableCell>
+                                        <TableCell>
+                                          {isEditingEntryDate ? (
+                                            <div className="flex items-center gap-2">
+                                              <DatePicker
+                                                date={
+                                                  editedEntryDate &&
+                                                  editedEntryDate !== ''
+                                                    ? (() => {
+                                                        try {
+                                                          // Handle YYYY-MM-DD format
+                                                          const dateStr =
+                                                            editedEntryDate.includes(
+                                                              'T'
+                                                            )
+                                                              ? editedEntryDate.split(
+                                                                  'T'
+                                                                )[0]
+                                                              : editedEntryDate;
+                                                          const parsed =
+                                                            new Date(
+                                                              dateStr +
+                                                                'T00:00:00'
+                                                            );
+                                                          return isNaN(
+                                                            parsed.getTime()
+                                                          )
+                                                            ? undefined
+                                                            : parsed;
+                                                        } catch {
+                                                          return undefined;
+                                                        }
+                                                      })()
+                                                    : undefined
+                                                }
+                                                onDateChange={(date) =>
+                                                  setEditedEntryDate(
+                                                    date
+                                                      ? format(
+                                                          date,
+                                                          'yyyy-MM-dd'
+                                                        )
+                                                      : ''
+                                                  )
+                                                }
+                                              />
+
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() =>
+                                                  handleEntryDateSaveClick(task)
+                                                }
+                                              >
+                                                <CheckIcon className="h-4 w-4 text-green-500" />
+                                              </Button>
+
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() =>
+                                                  setIsEditingEntryDate(false)
+                                                }
+                                              >
+                                                <XIcon className="h-4 w-4 text-red-500" />
+                                              </Button>
+                                            </div>
+                                          ) : (
+                                            <>
+                                              <span>
+                                                {formattedDate(task.entry)}
+                                              </span>
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => {
+                                                  setIsEditingEntryDate(true);
+                                                  const entryDate = task.entry
+                                                    ? task.entry.includes('T')
+                                                      ? task.entry.split('T')[0]
+                                                      : task.entry
+                                                    : '';
+                                                  setEditedEntryDate(entryDate);
+                                                }}
+                                              >
+                                                <PencilIcon className="h-4 w-4 text-gray-500" />
+                                              </Button>
+                                            </>
                                           )}
                                         </TableCell>
                                       </TableRow>

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -90,6 +90,7 @@ export const editTaskOnBackend = async ({
   backendURL,
   project,
   start,
+  entry,
 }: {
   email: string;
   encryptionSecret: string;
@@ -100,6 +101,7 @@ export const editTaskOnBackend = async ({
   backendURL: string;
   project: string;
   start: string;
+  entry: string;
 }) => {
   const response = await fetch(`${backendURL}edit-task`, {
     method: 'POST',
@@ -112,6 +114,7 @@ export const editTaskOnBackend = async ({
       tags,
       project,
       start,
+      entry,
     }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
### Description
Made the entry field editable in task details. Users can now click the pencil icon, select a date using the DatePicker, and save changes.

- Contributes to: #166 
 
### Changes
- Added entry field to backend EditTaskRequestBody
- Updated edit_task controller and taskwarrior function to handle entry parameter
- Added DatePicker UI for entry field in Tasks.tsx
- Updated hooks.ts to send entry in API request

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Verified all tests pass
- [x] Build completed successfully

### Screenshot:
<img width="1353" height="1006" alt="image" src="https://github.com/user-attachments/assets/eebb9989-8c62-4c8a-bf34-2aa4e0277597" />


### Demo Video

https://github.com/user-attachments/assets/39192136-be09-4751-a0ec-c38263425ac0



### Additional Notes
Tested locally and verified the entry field editing works correctly, 

