### PR TITLE
Feat/186/overdue filter

### DIFF
--- a/backend/utils/tw/export_tasks.go
+++ b/backend/utils/tw/export_tasks.go
@@ -5,7 +5,6 @@ import (
 	"ccsync_backend/utils"
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 // export the tasks so as to add them to DB
@@ -21,25 +20,11 @@ func ExportTasks(tempDir string) ([]models.Task, error) {
 		return nil, fmt.Errorf("error parsing tasks: %v", err)
 	}
 
-	now := time.Now()
 	for i := range tasks {
 		if tasks[i].Status != "pending" || tasks[i].Due == "" {
 			continue
 		}
 
-		// Taskwarrior uses timestamps like 20060102T150405Z
-		dueTime, err := time.Parse("20060102T150405Z", tasks[i].Due)
-		if err != nil {
-			// Fallback to RFC3339
-			dueTime, err = time.Parse(time.RFC3339, tasks[i].Due)
-			if err != nil {
-				continue
-			}
-		}
-
-		if dueTime.Before(now) {
-			tasks[i].Status = "overdue"
-		}
 	}
 
 	return tasks, nil

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -55,6 +55,7 @@ import {
   sortTasksById,
   getTimeSinceLastSync,
   hashKey,
+  isTaskOverdue,
 } from './tasks-utils';
 import Pagination from './Pagination';
 import { url } from '@/components/utils/URLs';
@@ -461,9 +462,16 @@ export const Tasks = (
 
     //Status filter
     if (selectedStatuses.length > 0) {
-      filteredTasks = filteredTasks.filter((task) =>
-        selectedStatuses.includes(task.status)
-      );
+      const wantsOverdue = selectedStatuses.includes('overdue');
+      const realStatuses = selectedStatuses.filter((s) => s !== 'overdue');
+
+      filteredTasks = filteredTasks.filter((task) => {
+        const isRealStatusMatch = realStatuses.includes(task.status);
+        const isOverdueMatch =
+          wantsOverdue && task.status === 'pending' && isTaskOverdue(task);
+
+        return isRealStatusMatch || isOverdueMatch;
+      });
     }
 
     // Tag filter
@@ -923,28 +931,39 @@ export const Tasks = (
                                   )}
                                 </TableCell>
                                 <TableCell className="py-2">
-                                  <Badge
-                                    variant={
-                                      task.status === 'pending'
-                                        ? 'secondary'
-                                        : task.status === 'deleted'
-                                          ? 'destructive'
-                                          : 'default'
-                                    }
-                                    className={
-                                      task.status === 'overdue'
-                                        ? 'bg-orange-500 border-transparent'
-                                        : undefined
-                                    }
-                                  >
-                                    {task.status === 'overdue'
-                                      ? 'O'
-                                      : task.status === 'completed'
-                                        ? 'C'
-                                        : task.status === 'deleted'
-                                          ? 'D'
-                                          : 'P'}
-                                  </Badge>
+                                  {(() => {
+                                    const overdue = isTaskOverdue(task);
+                                    return (
+                                      <Badge
+                                        variant={
+                                          task.status === 'pending'
+                                            ? 'secondary'
+                                            : task.status === 'deleted'
+                                              ? 'destructive'
+                                              : 'default'
+                                        }
+                                        className={
+                                          overdue
+                                            ? 'bg-orange-500 text-white border-transparent'
+                                            : task.status === 'pending'
+                                              ? 'bg-gray-500 text-white'
+                                              : task.status === 'completed'
+                                                ? 'bg-green-600 text-white'
+                                                : task.status === 'deleted'
+                                                  ? 'bg-red-600 text-white'
+                                                  : ''
+                                        }
+                                      >
+                                        {overdue
+                                          ? 'O'
+                                          : task.status === 'completed'
+                                            ? 'C'
+                                            : task.status === 'deleted'
+                                              ? 'D'
+                                              : 'P'}
+                                      </Badge>
+                                    );
+                                  })()}
                                 </TableCell>
                               </TableRow>
                             </DialogTrigger>

--- a/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
+++ b/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
@@ -1,7 +1,7 @@
 import { Task } from '@/components/utils/types';
 import { url } from '@/components/utils/URLs';
-import { format, parseISO } from 'date-fns';
 import { toast } from 'react-toastify';
+import { format, parseISO, isBefore } from 'date-fns';
 
 export type Props = {
   email: string;
@@ -182,4 +182,14 @@ export const hashKey = (key: string, email: string): string => {
     hash = hash & hash; // Convert to 32-bit integer
   }
   return Math.abs(hash).toString(36);
+};
+
+export const isTaskOverdue = (task: Task) => {
+  if (task.status !== 'pending' || !task.due) return false;
+
+  try {
+    return isBefore(parseISO(task.due), new Date());
+  } catch {
+    return false; // ignore malformed due dates
+  }
 };


### PR DESCRIPTION
### Description

- Added an overdue filter to the existing status filters.
- Added an orange-coloured badge for overdue tasks.
- Implemented the code both in backend and frontend

- Fixes: #186 

### Checklist

- [ x ] Ran `npx prettier --write .` (for formatting)
- [ x ] Ran `gofmt -w .` (for Go backend)
- [ x ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ x ] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes


https://github.com/user-attachments/assets/167e3597-b6f2-4888-b560-ae47a6b5aff0


