### PR TITLE
feat(tasks): add visual indicator for unsynced local changes

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -60,6 +60,7 @@ export const TaskDialog = ({
   onMarkComplete,
   onMarkDeleted,
   isOverdue,
+  isUnsynced,
 }: EditTaskDialogProps) => {
   const handleDialogOpenChange = (open: boolean) => {
     if (open) {
@@ -127,6 +128,11 @@ export const TaskDialog = ({
               <Badge variant={'secondary'}>
                 <Folder className="pr-2" />
                 {task.project === '' ? '' : task.project}
+              </Badge>
+            )}
+            {isUnsynced && (
+              <Badge variant={'destructive'} className="animate-pulse">
+                Unsynced
               </Badge>
             )}
           </TableCell>
@@ -205,6 +211,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="save"
                             onClick={() => {
                               onSaveDescription(
                                 task,
@@ -218,6 +225,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="cancel"
                             onClick={handleCancelClick}
                           >
                             <XIcon className="h-4 w-4 text-red-500" />
@@ -230,6 +238,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => handleEditClick(task.description)}
                         >
                           <PencilIcon className="h-4 w-4 text-gray-500" />
@@ -277,6 +286,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSaveDueDate(task, editState.editedDueDate);
                             onUpdateState({ isEditingDueDate: false });
@@ -287,6 +297,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               editedDueDate: task.due || '',
@@ -303,6 +314,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingDueDate: true,
@@ -362,6 +374,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSaveStartDate(task, editState.editedStartDate);
                             onUpdateState({ isEditingStartDate: false });
@@ -373,6 +386,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               editedStartDate: task.start || '',
@@ -389,6 +403,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingStartDate: true,
@@ -445,6 +460,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSaveEndDate(task, editState.editedEndDate);
                             onUpdateState({ isEditingEndDate: false });
@@ -455,6 +471,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               editedEndDate: task.end || '',
@@ -471,6 +488,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingEndDate: true,
@@ -527,6 +545,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSaveWaitDate(task, editState.editedWaitDate);
                             onUpdateState({ isEditingWaitDate: false });
@@ -538,6 +557,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               editedWaitDate: task.wait || '',
@@ -554,6 +574,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingWaitDate: true,
@@ -601,6 +622,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingDepends: true,
@@ -659,7 +681,10 @@ export const TaskDialog = ({
                               Add Dependency
                             </Button>
                             {editState.dependsDropdownOpen && (
-                              <div className="absolute left-0 top-full mt-1 z-50 w-full bg-background border rounded-md shadow-lg max-h-60 overflow-y-auto">
+                              <div
+                                data-testid="dependency-dropdown"
+                                className="absolute left-0 top-full mt-1 z-50 w-full bg-background border rounded-md shadow-lg max-h-60 overflow-y-auto"
+                              >
                                 <Input
                                   type="text"
                                   placeholder="Search tasks..."
@@ -717,6 +742,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="save"
                             onClick={() => {
                               onSaveDepends(task, editState.editedDepends);
                               onUpdateState({
@@ -730,6 +756,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="cancel"
                             onClick={() => {
                               onUpdateState({
                                 isEditingDepends: false,
@@ -771,6 +798,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSavePriority(task, editState.editedPriority);
                             onUpdateState({ isEditingPriority: false });
@@ -781,6 +809,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() => {
                             onUpdateState({
                               editedPriority: task.priority || 'NONE',
@@ -807,6 +836,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() =>
                             onUpdateState({
                               editedPriority: task.priority || 'NONE',
@@ -841,6 +871,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="save"
                             onClick={() => {
                               onSaveProject(task, editState.editedProject);
                               onUpdateState({ isEditingProject: false });
@@ -851,6 +882,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="cancel"
                             onClick={() =>
                               onUpdateState({
                                 editedProject: task.project,
@@ -868,6 +900,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               editedProject: task.project,
@@ -930,6 +963,7 @@ export const TaskDialog = ({
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="Save tags"
                             onClick={() => {
                               onSaveTags(task, editState.editedTags);
                               onUpdateState({
@@ -937,13 +971,13 @@ export const TaskDialog = ({
                                 editTagInput: '',
                               });
                             }}
-                            aria-label="Save tags"
                           >
                             <CheckIcon className="h-4 w-4 text-green-500" />
                           </Button>
                           <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="Cancel editing tags"
                             onClick={() => {
                               onUpdateState({
                                 isEditingTags: false,
@@ -951,7 +985,6 @@ export const TaskDialog = ({
                                 editTagInput: '',
                               });
                             }}
-                            aria-label="Cancel editing tags"
                           >
                             <XIcon className="h-4 w-4 text-red-500" />
                           </Button>
@@ -1004,6 +1037,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() =>
                             onUpdateState({
                               isEditingTags: true,
@@ -1060,6 +1094,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() => {
                             onSaveEntryDate(task, editState.editedEntryDate);
                             onUpdateState({ isEditingEntryDate: false });
@@ -1071,6 +1106,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               isEditingEntryDate: false,
@@ -1091,6 +1127,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() =>
                             onUpdateState({
                               isEditingEntryDate: true,
@@ -1160,6 +1197,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="save"
                           onClick={() =>
                             onSaveRecur(task, editState.editedRecur)
                           }
@@ -1169,6 +1207,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
                               isEditingRecur: false,
@@ -1185,6 +1224,7 @@ export const TaskDialog = ({
                         <Button
                           variant="ghost"
                           size="icon"
+                          aria-label="edit"
                           onClick={() => {
                             onUpdateState({
                               isEditingRecur: true,
@@ -1368,7 +1408,10 @@ export const TaskDialog = ({
           {task.status == 'pending' ? (
             <Dialog>
               <DialogTrigger asChild className="mr-5">
-                <Button id={`mark-task-complete-${task.id}`}>
+                <Button
+                  id={`mark-task-complete-${task.id}`}
+                  aria-label="complete task"
+                >
                   Mark As Completed <Key lable="c" />
                 </Button>
               </DialogTrigger>
@@ -1408,6 +1451,7 @@ export const TaskDialog = ({
                   id={`mark-task-as-deleted-${task.id}`}
                   className="mr-4"
                   variant={'destructive'}
+                  aria-label="delete task"
                 >
                   <Trash2Icon />
                   <Key lable="d" />

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/TaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/TaskDialog.test.tsx
@@ -100,6 +100,7 @@ describe('TaskDialog Component', () => {
     onMarkComplete: jest.fn(),
     onMarkDeleted: jest.fn(),
     isOverdue: jest.fn(() => false),
+    isUnsynced: false,
   };
 
   beforeEach(() => {
@@ -125,6 +126,31 @@ describe('TaskDialog Component', () => {
 
       const statusBadge = screen.getByText('O');
       expect(statusBadge).toBeInTheDocument();
+    });
+
+    test('should display Unsynced badge when isUnsynced is true', () => {
+      const unsyncedProps = {
+        ...defaultProps,
+        isUnsynced: true,
+      };
+
+      render(<TaskDialog {...unsyncedProps} />);
+
+      const unsyncedBadge = screen.getByText('Unsynced');
+      expect(unsyncedBadge).toBeInTheDocument();
+      expect(unsyncedBadge).toHaveClass('animate-pulse');
+    });
+
+    test('should not display Unsynced badge when isUnsynced is false', () => {
+      const unsyncedProps = {
+        ...defaultProps,
+        isUnsynced: false,
+      };
+
+      render(<TaskDialog {...unsyncedProps} />);
+
+      const unsyncedBadge = screen.queryByText('Unsynced');
+      expect(unsyncedBadge).not.toBeInTheDocument();
     });
 
     test('should display correct priority indicator', () => {
@@ -584,7 +610,7 @@ describe('TaskDialog Component', () => {
       render(<TaskDialog {...defaultProps} isOpen={true} />);
 
       const deleteButton = screen.getByRole('button', {
-        name: /^d$/i,
+        name: /delete task/i,
       });
       fireEvent.click(deleteButton);
 

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -120,13 +120,20 @@ jest.mock('../hooks', () => ({
               uuid: 'uuid-corp-3',
             },
           ]),
+          delete: jest.fn().mockResolvedValue(undefined),
         })),
       })),
+      bulkPut: jest.fn().mockResolvedValue(undefined),
     },
+    transaction: jest.fn(async (_mode, _table, callback) => {
+      await callback();
+      return Promise.resolve();
+    }),
   })),
   fetchTaskwarriorTasks: jest.fn().mockResolvedValue([]),
   addTaskToBackend: jest.fn().mockResolvedValue({}),
   editTaskOnBackend: jest.fn().mockResolvedValue({}),
+  modifyTaskOnBackend: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('../Pagination', () => {
@@ -348,6 +355,7 @@ describe('Tasks Component', () => {
     const overdueBadge = await screen.findByText('Overdue');
     expect(overdueBadge).toBeInTheDocument();
   });
+
   test('filters tasks with fuzzy search (handles typos)', async () => {
     jest.useFakeTimers();
 
@@ -531,6 +539,381 @@ describe('Tasks Component', () => {
           'Search and select tasks this depends on...'
         )
       ).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task is marked as completed', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      const completeButton = screen.getByLabelText('complete task');
+      fireEvent.click(completeButton);
+    });
+
+    const yesButton = screen.getAllByText('Yes')[0];
+    fireEvent.click(yesButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task is deleted', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      const deleteButton = screen.getByLabelText('delete task');
+      fireEvent.click(deleteButton);
+    });
+
+    await waitFor(() => {
+      const yesButtons = screen.getAllByText('Yes');
+      if (yesButtons.length > 0) fireEvent.click(yesButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task description is edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Description:')).toBeInTheDocument();
+    });
+
+    const descriptionLabel = screen.getByText('Description:');
+    const descRow = descriptionLabel.closest('tr') as HTMLElement;
+    const editButton = within(descRow).getByLabelText('edit');
+
+    fireEvent.click(editButton);
+
+    const input = await screen.findByDisplayValue('Task 12');
+
+    fireEvent.change(input, { target: { value: 'Updated Task 12' } });
+
+    const saveButton = screen.getByLabelText('save');
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task project is edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Project:')).toBeInTheDocument();
+    });
+
+    const projectLabel = screen.getByText('Project:');
+    const projectRow = projectLabel.closest('tr') as HTMLElement;
+    const editButton = within(projectRow).getByLabelText('edit');
+
+    fireEvent.click(editButton);
+
+    const input = await screen.findByDisplayValue('ProjectB');
+
+    fireEvent.change(input, { target: { value: 'UpdatedProject' } });
+
+    const saveButton = screen.getByLabelText('save');
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test.each([
+    ['Wait', 'Wait:', 'Pick a date'],
+    ['End', 'End:', 'Select end date'],
+    ['Due', 'Due:', 'Select due date'],
+    ['Start', 'Start:', 'Pick a date'],
+    ['Entry', 'Entry:', 'Pick a date'],
+  ])(
+    'shows "Unsynced" badge when task %s date is edited',
+    async (_, label, placeholder) => {
+      render(<Tasks {...mockProps} />);
+
+      await waitFor(async () => {
+        expect(await screen.findByText('Task 12')).toBeInTheDocument();
+      });
+
+      const task12 = screen.getByText('Task 12');
+      fireEvent.click(task12);
+
+      await waitFor(() => {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+
+      const dateLabel = screen.getByText(label);
+      const dateRow = dateLabel.closest('tr') as HTMLElement;
+
+      const editButton = within(dateRow).getByLabelText('edit');
+      fireEvent.click(editButton);
+
+      const dateButton = within(dateRow)
+        .getByText(placeholder)
+        .closest('button');
+      fireEvent.click(dateButton!);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const dialog = screen.getByRole('dialog');
+      const day15 = within(dialog).getByText('15');
+      fireEvent.click(day15);
+
+      const saveButton = screen.getByLabelText('save');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Unsynced')).toBeInTheDocument();
+      });
+    }
+  );
+
+  test('shows "Unsynced" badge when task priority is edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Priority:')).toBeInTheDocument();
+    });
+
+    const priorityLabel = screen.getByText('Priority:');
+    const priorityRow = priorityLabel.closest('tr') as HTMLElement;
+
+    const editButton = within(priorityRow).getByLabelText('edit');
+    fireEvent.click(editButton);
+
+    const select = within(priorityRow).getByTestId('project-select');
+    fireEvent.change(select, { target: { value: 'H' } });
+
+    const saveButton = screen.getByLabelText('save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task dependencies are edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Depends:')).toBeInTheDocument();
+    });
+
+    const dependsLabel = screen.getByText('Depends:');
+    const dependsRow = dependsLabel.closest('tr') as HTMLElement;
+
+    const editButton = within(dependsRow).getByLabelText('edit');
+    fireEvent.click(editButton);
+
+    const addDependecyButton = within(dependsRow)
+      .getByText('Add Dependency')
+      .closest('button');
+    fireEvent.click(addDependecyButton!);
+
+    const dropdown = within(dependsRow).getByTestId('dependency-dropdown');
+
+    fireEvent.click(within(dropdown).getByText('Task 11'));
+    fireEvent.click(within(dropdown).getByText('Task 10'));
+
+    const saveButton = screen.getByLabelText('save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task tags are edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tags:')).toBeInTheDocument();
+    });
+
+    const tagsLabel = screen.getByText('Tags:');
+    const tagsRow = tagsLabel.closest('tr') as HTMLElement;
+
+    const editButton = within(tagsRow).getByLabelText('edit');
+    fireEvent.click(editButton);
+
+    const editInput = await screen.findByPlaceholderText(
+      'Add a tag (press enter to add)'
+    );
+
+    fireEvent.change(editInput, { target: { value: 'unsyncedtag' } });
+    fireEvent.keyDown(editInput, { key: 'Enter', code: 'Enter' });
+
+    const saveButton = screen.getByLabelText('Save tags');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows "Unsynced" badge when task recur is edited', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      expect(screen.getByText('Recur:')).toBeInTheDocument();
+    });
+
+    const recurLabel = screen.getByText('Recur:');
+    const recurRow = recurLabel.closest('tr') as HTMLElement;
+
+    const editButton = within(recurRow).getByLabelText('edit');
+    fireEvent.click(editButton);
+
+    const select = within(recurRow).getByTestId('project-select');
+    fireEvent.change(select, { target: { value: 'weekly' } });
+
+    const saveButton = screen.getByLabelText('save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+  });
+
+  test('shows and updates notification badge count on Sync button', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      const completeButton = screen.getByLabelText('complete task');
+      fireEvent.click(completeButton);
+    });
+
+    const yesButton = screen.getAllByText('Yes')[0];
+    fireEvent.click(yesButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+
+    const syncButtons = screen.getAllByText('Sync');
+    const syncBtnContainer = syncButtons[0].closest('button');
+
+    if (syncBtnContainer) {
+      expect(within(syncBtnContainer).getByText('1')).toBeInTheDocument();
+    } else {
+      throw new Error('Sync button not found');
+    }
+  });
+
+  test('clears "Unsynced" badges after sync', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Task 12')).toBeInTheDocument();
+    });
+
+    const task12 = screen.getByText('Task 12');
+    fireEvent.click(task12);
+
+    await waitFor(() => {
+      const completeButton = screen.getByLabelText('complete task');
+      fireEvent.click(completeButton);
+    });
+
+    const yesButton = screen.getAllByText('Yes')[0];
+    fireEvent.click(yesButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsynced')).toBeInTheDocument();
+    });
+
+    const hooks = require('../hooks');
+    hooks.fetchTaskwarriorTasks.mockResolvedValueOnce([
+      {
+        id: 12,
+        description: 'Task 12',
+        status: 'completed',
+        project: 'ProjectA',
+        tags: ['tag1'],
+        uuid: 'uuid-12',
+      },
+    ]);
+
+    const syncButtons = screen.getAllByText('Sync');
+    fireEvent.click(syncButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Unsynced')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -151,4 +151,5 @@ export interface EditTaskDialogProps {
   onMarkComplete: (uuid: string) => void;
   onMarkDeleted: (uuid: string) => void;
   isOverdue: (due?: string) => boolean;
+  isUnsynced: boolean;
 }


### PR DESCRIPTION
### Description

This PR implements **visual indicators for unsynced task modifications**. When a task is edited, completed, or deleted, the UI immediately marks it as **"Unsynced"** until the backend successfully synchronizes all pending changes.

- Closes: #143

### Key Changes
- **State Management:** Implements a local state `unsyncedTaskUuids` to track tasks modified on the frontend but not yet synced to the backend.
- **Visual Indicators:**
  - Adds a **red "Unsynced" badge** to task rows for immediate feedback when a task is edited, completed, or deleted.
  - Displays the **count of pending unsynced items** on the Sync button via a notification-style badge.
- **Optimistic UI Updates:** Immediately updates UI for task status changes (completed/deleted) to enhance perceived performance.
- **Sync Logic:** Automatically clears all unsynced indicators once backend synchronization succeeds.

- **Testing**
  - Includes unit tests verifying:
    - Unsynced badge visibility  
    - Sync button counter accuracy  
    - Clearing state on successful sync
    - Used `test.each` for repetitive date editing tests, reducing code duplication.

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

Video: [Link to see changes](https://drive.google.com/file/d/1lJoPKuyjC2lyuQ0KqcBKWKXhxW_D0yjL/view?usp=sharing)
