### PR TITLE
feat(tasks): highlight overdue tasks and show overdue badge in dialog

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -56,6 +56,7 @@ jest.mock('../hooks', () => ({
               project: i % 2 === 0 ? 'ProjectA' : 'ProjectB',
               tags: i % 3 === 0 ? ['tag1'] : ['tag2'],
               uuid: `uuid-${i + 1}`,
+              due: i === 0 ? '20200101T120000Z' : undefined,
             }))
           ),
         })),
@@ -143,5 +144,24 @@ describe('Tasks Component', () => {
     expect(localStorageMock.setItem).toHaveBeenCalledWith('mockHashedKey', '5');
 
     expect(screen.getByTestId('current-page')).toHaveTextContent('1');
+  });
+
+  test('shows red background on task ID and Overdue badge for overdue tasks', async () => {
+    render(<Tasks {...mockProps} />);
+
+    await screen.findByText('Task 12');
+
+    const dropdown = screen.getByLabelText('Show:');
+    fireEvent.change(dropdown, { target: { value: '20' } });
+
+    const task1Description = screen.getByText('Task 1');
+    const row = task1Description.closest('tr');
+    const idElement = row?.querySelector('span');
+
+    expect(idElement).toHaveClass('bg-red-600/80');
+    fireEvent.click(idElement!);
+
+    const overdueBadge = await screen.findByText('Overdue');
+    expect(overdueBadge).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Overdue Task Highlighting & Prioritization

This PR implements improved visibility for overdue tasks, making it easier for users to quickly identify pending work that requires immediate attention.

- Added **red background styling** to task IDs when the due date has passed  
- Added an **"Overdue" badge** inside the task details dialog for pending + overdue tasks  
- Implemented **sorting logic** to always place overdue tasks at the top of the list  
- Updated search and filter flows to keep **overdue-first ordering** consistent  
- Added unit tests to verify overdue styling and badge rendering 

## Description

<!-- Provide a brief description of the changes made in this PR -->

- Fixes: #152

## Checklist

- [x] Ran `npx prettier --write .` (for formatting)  
- [ ] Ran `gofmt -w .` (for Go backend)  
- [x] Ran `npm test` (for JS/TS testing)  
- [x] Added unit tests, if applicable  
- [x] Verified all tests pass  
- [ ] Updated documentation, if needed  

## Additional Notes

#### Video: [Link](https://drive.google.com/file/d/1LofkciFnYMjlPzKnAY4ctXx9Gj3EMlQg/view?usp=sharing)

#### Screenshots

<img width="1440" height="783" alt="Screenshot 2025-11-19 at 9 12 50 AM" src="https://github.com/user-attachments/assets/c35aa40a-f8a8-489b-b0a7-741df8fcb79e" />

<img width="1431" height="792" alt="Screenshot 2025-11-19 at 9 13 02 AM" src="https://github.com/user-attachments/assets/c2ab76d6-7a23-4b43-8241-58b002454442" />

<img width="403" height="456" alt="Screenshot 2025-11-19 at 9 12 30 AM" src="https://github.com/user-attachments/assets/2d0ebc6a-0065-43b3-af2f-30a00f7aa830" />

<img width="364" height="434" alt="Screenshot 2025-11-19 at 9 13 09 AM" src="https://github.com/user-attachments/assets/9ed954d7-3d5f-40d0-93b4-0d6039e10c00" />
