### PR TITLE
feat: add editable depends field to task details

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -50,6 +50,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 		entry := requestBody.Entry
 		wait := requestBody.Wait
 		end := requestBody.End
+		depends := requestBody.Depends
 
 		if taskID == "" {
 			http.Error(w, "taskID is required", http.StatusBadRequest)
@@ -61,7 +62,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Edit Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Editing task ID: %s", taskID), uuid, "Edit Task")
-				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end)
+				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end, depends)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to edit task ID %s: %v", taskID, err), uuid, "Edit Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -35,6 +35,7 @@ type EditTaskRequestBody struct {
 	Entry            string   `json:"entry"`
 	Wait             string   `json:"wait"`
 	End              string   `json:"end"`
+	Depends          []string `json:"depends"`
 }
 type CompleteTaskRequestBody struct {
 	Email            string `json:"email"`

--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string) error {
+func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string, depends []string) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -91,6 +91,14 @@ func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID st
 	if end != "" {
 		if err := utils.ExecCommand("task", taskID, "modify", "end:"+end); err != nil {
 			return fmt.Errorf("failed to set end date %s: %v", end, err)
+		}
+	}
+
+	// Handle depends
+	if len(depends) > 0 {
+		dependsStr := strings.Join(depends, ",")
+		if err := utils.ExecCommand("task", taskID, "modify", "depends:"+dependsStr); err != nil {
+			return fmt.Errorf("failed to set depends %s: %v", dependsStr, err)
 		}
 	}
 

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -23,7 +23,7 @@ func TestSyncTaskwarrior(t *testing.T) {
 }
 
 func TestEditTaskInATaskwarrior(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior() failed: %v", err)
 	} else {
@@ -68,7 +68,7 @@ func TestAddTaskWithTags(t *testing.T) {
 }
 
 func TestEditTaskWithTagAddition(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag addition failed: %v", err)
 	} else {
@@ -77,7 +77,7 @@ func TestEditTaskWithTagAddition(t *testing.T) {
 }
 
 func TestEditTaskWithTagRemoval(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag removal failed: %v", err)
 	} else {
@@ -86,7 +86,7 @@ func TestEditTaskWithTagRemoval(t *testing.T) {
 }
 
 func TestEditTaskWithMixedTagOperations(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z")
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with mixed tag operations failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
@@ -36,7 +36,7 @@ const createTask = (
   email: '',
   start: '',
   wait: '',
-  depends: [''],
+  depends: [],
   rtype: '',
   recur: '',
 });

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -93,6 +93,7 @@ export const editTaskOnBackend = async ({
   entry,
   wait,
   end,
+  depends,
 }: {
   email: string;
   encryptionSecret: string;
@@ -106,6 +107,7 @@ export const editTaskOnBackend = async ({
   entry: string;
   wait: string;
   end: string;
+  depends: string[];
 }) => {
   const response = await fetch(`${backendURL}edit-task`, {
     method: 'POST',
@@ -121,6 +123,7 @@ export const editTaskOnBackend = async ({
       entry,
       wait,
       end,
+      depends,
     }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

Makes the depends field editable in task details. Dependencies display as clickable badges showing task descriptions. Click a dependency to open that task's modal.

=> Contributes to: #166

## Changes

- Add depends field to task edit request model
- Update edit task controller to handle depends parameter
- Implement depends field modification in taskwarrior
- Add depends field UI with inline editing
- Display dependencies as badges with task descriptions
- Implement clickable dependency badges that open corresponding task modal
- Add searchable dropdown for adding dependencies
- Add remove button on each dependency badge
- Fix test cases to match depends field type

## Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

## Additional Notes

- Dependencies show as task descriptions, not UUIDs
- Click dependency badge to navigate to that task
- Search filters pending tasks when adding dependencies
- Empty field shows blank for consistency

##Screenshots 
<img width="1362" height="931" alt="Screenshot from 2025-11-25 12-57-59" src="https://github.com/user-attachments/assets/05ba5f00-4399-487f-9e3b-6c9846cf2951" />
<img width="1362" height="931" alt="Screenshot from 2025-11-25 12-58-33" src="https://github.com/user-attachments/assets/63a54ad8-8d47-43a9-a3e8-d92abbb59c30" />

** screen record 

https://github.com/user-attachments/assets/ed0d50f7-7edc-4ec1-8725-b3a4b169d9e9


https://github.com/user-attachments/assets/e06ec772-ec0c-4582-8424-50eb46e66251



