### PR TITLE
feat(tasks): implement fuzzy search using Fuse.js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -135,6 +135,7 @@
         "framer-motion": "^11.3.8",
         "fs.realpath": "^1.0.0",
         "function-bind": "^1.1.2",
+        "fuse.js": "^7.1.0",
         "gensync": "^1.0.0-beta.2",
         "get-caller-file": "^2.0.5",
         "get-nonce": "^1.0.1",
@@ -7754,6 +7755,15 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,7 @@
     "framer-motion": "^11.3.8",
     "fs.realpath": "^1.0.0",
     "function-bind": "^1.1.2",
+    "fuse.js": "^7.1.0",
     "gensync": "^1.0.0-beta.2",
     "get-caller-file": "^2.0.5",
     "get-nonce": "^1.0.1",


### PR DESCRIPTION
# Description

This PR adds **fuzzy search** to the Tasks screen using `Fuse.js`, replacing the previous exact-match `.includes()` search.  
With this, users can now find tasks using partial matches or minor typos.

Fixes: #162

---

# Key Changes

### Fuzzy Search Integration
- Integrated `Fuse.js` for fuzzy matching on `description`, `project`, and `tags`.
- Configured a threshold for balanced relevance.
- Search now respects all existing filters (project, tags, status).

### Improved Search UX
- Added a two-state search (`searchInput` + `debouncedTerm`) with 300ms debounce.
- Prevents unnecessary searches on every keystroke.

### Unified Filtering Logic
- Combined search + tag/project/status filters into one master filtering `useEffect`.
- Ensures consistent results across all filter combinations.

### Test Updates
- Updated Jest tests for fuzzy search behavior.
- Added tests for typo tolerance (e.g., `"fiace"` → `"Finance"`).

---

# Checklist

- [x] Ran `npx prettier --write .`
- [ ] Ran `gofmt -w .` (Go backend)
- [x] Ran `npm test`
- [x] Added/updated unit tests
- [x] All tests passing
- [ ] Documentation updated if needed

---

# Additional Notes

**Video demo:** [Click here to see](https://drive.google.com/file/d/1QDne-XwVBZqU-rNAjRt4Ful7gsnnnONX/view?usp=sharing)