### PR TITLE
fixed sorting by ID bug

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -581,13 +581,13 @@ export const Tasks = (
       if (aOverdue && !bOverdue) return -1;
       if (!aOverdue && bOverdue) return 1;
 
-      // Otherwise fall back to ID sort DESC (latest first)
-      return b.id - a.id;
+      // Otherwise fall back to ID sort and status sort
+      return 0;
     });
   };
 
   useEffect(() => {
-    let filteredTasks = tasks;
+    let filteredTasks = [...tasks];
 
     // Project filter
     if (selectedProjects.length > 0) {


### PR DESCRIPTION
### Description

Previously, sorting tasks manually (e.g., by ID or description) would appear to work initially, but the order would be unexpectedly overridden whenever filters or other state changes triggered a re-render. The source of the problem was that sortWithOverdueOnTop() always applied a second sort — forcing sorting by ID again — which erased the user’s intended sort order.

### What was causing it:

The useEffect that filters tasks also re-applied sorting.
Inside sortWithOverdueOnTop(), we performed:
`return b.id - a.id;`
Which forced DESC ID sorting again every time the effect ran, overriding any custom sorting logic.

### Fix introduced:

Updated sortWithOverdueOnTop() to only enforce the overdue-first rule, without altering the order of non-overdue tasks:
`return 0;`
This preserves the user’s chosen sorting order while still keeping overdue tasks at the top.
Ensured that manual sorting functions (handleIdSort, handleSort) continue to work correctly without unexpected overrides.

### Result:
✔ Overdue tasks always stay on top
✔ User-initiated sorting (ID, alphabetical, etc.) is preserved
✔ No more sorting conflicts when filters or state updates occur
✔ Improved UX consistency in the Tasks table

### - Fixes: #215 

### video after changes
[Screencast from 22-11-25 11:30:02 PM IST.webm](https://github.com/user-attachments/assets/bfe1b946-f0aa-4353-8bd2-4c8c8a4aa5ec)

