### PR TITLE
Changed the CSS

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -886,7 +886,7 @@ export const Tasks = (
                                       priority: e.target.value,
                                     })
                                   }
-                                  className="border rounded-md px-2 py-1 w-full bg-black text-white"
+                                  className="border rounded-md px-2 py-1 w-full bg-white text-black dark:bg-black dark:text-white transition-colors"
                                 >
                                   <option value="H">H</option>
                                   <option value="M">M</option>


### PR DESCRIPTION
### Description

Updated the Priority selector inside the Add Task modal so it now matches light mode styling: the select uses `bg-white text-black `by default and flips to `dark:bg-black dark:text-white`, making the dropdown align with the active theme.

- Fixes: #205 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
<img width="1872" height="961" alt="image" src="https://github.com/user-attachments/assets/4de1ea9e-e350-44b6-a471-3ab62bf7d7e0" />

