### PR TITLE
feat: add rtype field support to edit task API

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -51,6 +51,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 		wait := requestBody.Wait
 		end := requestBody.End
 		depends := requestBody.Depends
+		rtype := requestBody.RType
 
 		if taskID == "" {
 			http.Error(w, "taskID is required", http.StatusBadRequest)
@@ -62,7 +63,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Edit Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Editing task ID: %s", taskID), uuid, "Edit Task")
-				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end, depends)
+				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end, depends, rtype)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to edit task ID %s: %v", taskID, err), uuid, "Edit Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -36,6 +36,7 @@ type EditTaskRequestBody struct {
 	Wait             string   `json:"wait"`
 	End              string   `json:"end"`
 	Depends          []string `json:"depends"`
+	RType            string   `json:"rtype"`
 }
 type CompleteTaskRequestBody struct {
 	Email            string `json:"email"`

--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string, depends []string) error {
+func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string, depends []string, rtype string) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -101,6 +101,10 @@ func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID st
 			return fmt.Errorf("failed to set depends %s: %v", dependsStr, err)
 		}
 	}
+
+	// Note: rtype is read-only and automatically set by taskwarrior when recur field is set
+	// We accept it in the API for completeness but don't modify it directly
+	// If rtype needs to be changed, modify the recur field instead
 
 	// Sync Taskwarrior again
 	if err := SyncTaskwarrior(tempDir); err != nil {

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -23,7 +23,7 @@ func TestSyncTaskwarrior(t *testing.T) {
 }
 
 func TestEditTaskInATaskwarrior(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior() failed: %v", err)
 	} else {
@@ -68,7 +68,7 @@ func TestAddTaskWithTags(t *testing.T) {
 }
 
 func TestEditTaskWithTagAddition(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag addition failed: %v", err)
 	} else {
@@ -77,7 +77,7 @@ func TestEditTaskWithTagAddition(t *testing.T) {
 }
 
 func TestEditTaskWithTagRemoval(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag removal failed: %v", err)
 	} else {
@@ -86,7 +86,7 @@ func TestEditTaskWithTagRemoval(t *testing.T) {
 }
 
 func TestEditTaskWithMixedTagOperations(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with mixed tag operations failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -335,7 +335,8 @@ export const Tasks = (
     entry: string,
     wait: string,
     end: string,
-    depends: string[]
+    depends: string[],
+    rtype: string
   ) {
     try {
       await editTaskOnBackend({
@@ -352,6 +353,7 @@ export const Tasks = (
         wait,
         end,
         depends,
+        rtype,
       });
 
       console.log('Task edited successfully!');
@@ -398,7 +400,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
     setIsEditing(false);
   };
@@ -417,7 +420,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
     setIsEditingProject(false);
   };
@@ -437,7 +441,8 @@ export const Tasks = (
       task.entry || '',
       task.wait,
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
 
     setIsEditingWaitDate(false);
@@ -458,7 +463,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
 
     setIsEditingStartDate(false);
@@ -479,7 +485,8 @@ export const Tasks = (
       task.entry,
       task.wait,
       task.end,
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
 
     setIsEditingEntryDate(false);
@@ -500,7 +507,8 @@ export const Tasks = (
       task.entry,
       task.wait,
       task.end,
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
 
     setIsEditingEndDate(false);
@@ -521,7 +529,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends
+      task.depends,
+      task.rtype || ''
     );
 
     setIsEditingDepends(false);
@@ -679,7 +688,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.rtype || ''
     );
 
     setIsEditingTags(false);

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -94,6 +94,7 @@ export const editTaskOnBackend = async ({
   wait,
   end,
   depends,
+  rtype,
 }: {
   email: string;
   encryptionSecret: string;
@@ -108,6 +109,7 @@ export const editTaskOnBackend = async ({
   wait: string;
   end: string;
   depends: string[];
+  rtype: string;
 }) => {
   const response = await fetch(`${backendURL}edit-task`, {
     method: 'POST',
@@ -124,6 +126,7 @@ export const editTaskOnBackend = async ({
       wait,
       end,
       depends,
+      rtype,
     }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
### Description

Added rtype parameter to edit task flow for API completeness. RType is read-only and automatically managed by taskwarrior via recur field.

- Contributes to: #166

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

**Important:** RType is a read-only field that cannot be directly edited by users. It is automatically set by Taskwarrior when the `recur` field is modified. This PR adds rtype to the API for completeness but does not execute any taskwarrior commands to modify it directly.

When the recur field is implemented in a future PR, rtype will automatically be populated by Taskwarrior.

**Changes:**
- Backend: Added RType field to EditTaskRequestBody, controller, and taskwarrior function
- Frontend: Added rtype parameter to editTaskOnBackend hook and all related function calls
- Tests: Updated test function signatures to include rtype parameter
- Documentation: Added comment explaining rtype is read-only
