### PR TITLE
feat: make due field editable Added due field editing functionality t…

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -51,6 +51,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 		wait := requestBody.Wait
 		end := requestBody.End
 		depends := requestBody.Depends
+		due := requestBody.Due
 
 		if taskID == "" {
 			http.Error(w, "taskID is required", http.StatusBadRequest)
@@ -62,7 +63,7 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Edit Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Editing task ID: %s", taskID), uuid, "Edit Task")
-				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end, depends)
+				err := tw.EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID, tags, project, start, entry, wait, end, depends, due)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to edit task ID %s: %v", taskID, err), uuid, "Edit Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -36,6 +36,7 @@ type EditTaskRequestBody struct {
 	Wait             string   `json:"wait"`
 	End              string   `json:"end"`
 	Depends          []string `json:"depends"`
+	Due              string   `json:"due"`
 }
 type CompleteTaskRequestBody struct {
 	Email            string `json:"email"`

--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string, depends []string) error {
+func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID string, tags []string, project string, start string, entry string, wait string, end string, depends []string, due string) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -99,6 +99,16 @@ func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID st
 		dependsStr := strings.Join(depends, ",")
 		if err := utils.ExecCommand("task", taskID, "modify", "depends:"+dependsStr); err != nil {
 			return fmt.Errorf("failed to set depends %s: %v", dependsStr, err)
+		}
+	}
+
+	// Handle due date
+	if due != "" {
+		// Convert `2025-11-29` -> `2025-11-29T00:00:00`
+		formattedDue := due + "T00:00:00"
+
+		if err := utils.ExecCommand("task", taskID, "modify", "due:"+formattedDue); err != nil {
+			return fmt.Errorf("failed to set due date %s: %v", formattedDue, err)
 		}
 	}
 

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -23,7 +23,7 @@ func TestSyncTaskwarrior(t *testing.T) {
 }
 
 func TestEditTaskInATaskwarrior(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", nil, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "2025-12-01T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior() failed: %v", err)
 	} else {
@@ -68,7 +68,7 @@ func TestAddTaskWithTags(t *testing.T) {
 }
 
 func TestEditTaskWithTagAddition(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "+important"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "2025-12-01T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag addition failed: %v", err)
 	} else {
@@ -77,7 +77,7 @@ func TestEditTaskWithTagAddition(t *testing.T) {
 }
 
 func TestEditTaskWithTagRemoval(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"-work", "-lowpriority"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "2025-12-01T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with tag removal failed: %v", err)
 	} else {
@@ -86,7 +86,7 @@ func TestEditTaskWithTagRemoval(t *testing.T) {
 }
 
 func TestEditTaskWithMixedTagOperations(t *testing.T) {
-	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil)
+	err := EditTaskInTaskwarrior("uuid", "description", "email", "encryptionSecret", "taskuuid", []string{"+urgent", "-work", "normal"}, "project", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-29T18:30:00.000Z", "2025-11-30T18:30:00.000Z", nil, "2025-12-01T18:30:00.000Z")
 	if err != nil {
 		t.Errorf("EditTaskInTaskwarrior with mixed tag operations failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -130,6 +130,8 @@ export const Tasks = (
   const [editedEntryDate, setEditedEntryDate] = useState('');
   const [isEditingEndDate, setIsEditingEndDate] = useState(false);
   const [editedEndDate, setEditedEndDate] = useState('');
+  const [isEditingDueDate, setIsEditingDueDate] = useState(false);
+  const [editedDueDate, setEditedDueDate] = useState('');
   const [isEditingDepends, setIsEditingDepends] = useState(false);
   const [editedDepends, setEditedDepends] = useState<string[]>([]);
   const [dependsDropdownOpen, setDependsDropdownOpen] = useState(false);
@@ -376,7 +378,8 @@ export const Tasks = (
     entry: string,
     wait: string,
     end: string,
-    depends: string[]
+    depends: string[],
+    due: string
   ) {
     try {
       await editTaskOnBackend({
@@ -393,6 +396,7 @@ export const Tasks = (
         wait,
         end,
         depends,
+        due,
       });
 
       console.log('Task edited successfully!');
@@ -439,7 +443,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
     setIsEditing(false);
   };
@@ -458,7 +463,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
     setIsEditingProject(false);
   };
@@ -478,7 +484,8 @@ export const Tasks = (
       task.entry || '',
       task.wait,
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
 
     setIsEditingWaitDate(false);
@@ -499,7 +506,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
 
     setIsEditingStartDate(false);
@@ -520,7 +528,8 @@ export const Tasks = (
       task.entry,
       task.wait,
       task.end,
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
 
     setIsEditingEntryDate(false);
@@ -541,10 +550,33 @@ export const Tasks = (
       task.entry,
       task.wait,
       task.end,
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
 
     setIsEditingEndDate(false);
+  };
+
+  const handleDueDateSaveClick = (task: Task) => {
+    task.due = editedDueDate;
+
+    handleEditTaskOnBackend(
+      props.email,
+      props.encryptionSecret,
+      props.UUID,
+      task.description,
+      task.tags,
+      task.id.toString(),
+      task.project,
+      task.start,
+      task.entry,
+      task.wait,
+      task.end,
+      task.depends || [],
+      task.due
+    );
+
+    setIsEditingDueDate(false);
   };
 
   const handleDependsSaveClick = (task: Task) => {
@@ -562,7 +594,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends
+      task.depends,
+      task.due || ''
     );
 
     setIsEditingDepends(false);
@@ -598,6 +631,8 @@ export const Tasks = (
       setEditedEntryDate('');
       setIsEditingEndDate(false);
       setEditedEndDate('');
+      setIsEditingDueDate(false);
+      setEditedDueDate('');
       setIsEditingDepends(false);
       setEditedDepends([]);
       setDependsDropdownOpen(false);
@@ -720,7 +755,8 @@ export const Tasks = (
       task.entry || '',
       task.wait || '',
       task.end || '',
-      task.depends || []
+      task.depends || [],
+      task.due || ''
     );
 
     setIsEditingTags(false);
@@ -1200,7 +1236,9 @@ export const Tasks = (
                               <TableRow
                                 id={`task-row-${task.id}`}
                                 key={index}
-                                className={`border-b cursor-pointer ${selectedIndex === index ? 'bg-muted/50' : ''}`}
+                                className={`border-b cursor-pointer ${
+                                  selectedIndex === index ? 'bg-muted/50' : ''
+                                }`}
                               >
                                 {/* Display task details */}
                                 <TableCell className="py-2">
@@ -1341,7 +1379,91 @@ export const Tasks = (
                                       <TableRow>
                                         <TableCell>Due:</TableCell>
                                         <TableCell>
-                                          {formattedDate(task.due)}
+                                          {isEditingDueDate ? (
+                                            <div className="flex items-center gap-2">
+                                              <DatePicker
+                                                date={
+                                                  editedDueDate &&
+                                                  editedDueDate !== ''
+                                                    ? (() => {
+                                                        try {
+                                                          const dateStr =
+                                                            editedDueDate.includes(
+                                                              'T'
+                                                            )
+                                                              ? editedDueDate.split(
+                                                                  'T'
+                                                                )[0]
+                                                              : editedDueDate;
+                                                          const parsed =
+                                                            new Date(
+                                                              dateStr +
+                                                                'T00:00:00'
+                                                            );
+                                                          return isNaN(
+                                                            parsed.getTime()
+                                                          )
+                                                            ? undefined
+                                                            : parsed;
+                                                        } catch {
+                                                          return undefined;
+                                                        }
+                                                      })()
+                                                    : undefined
+                                                }
+                                                onDateChange={(date) =>
+                                                  setEditedDueDate(
+                                                    date
+                                                      ? format(
+                                                          date,
+                                                          'yyyy-MM-dd'
+                                                        )
+                                                      : ''
+                                                  )
+                                                }
+                                                placeholder="Select due date"
+                                              />
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() =>
+                                                  handleDueDateSaveClick(task)
+                                                }
+                                              >
+                                                <CheckIcon className="h-4 w-4 text-green-500" />
+                                              </Button>
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() =>
+                                                  setIsEditingDueDate(false)
+                                                }
+                                              >
+                                                <XIcon className="h-4 w-4 text-red-500" />
+                                              </Button>
+                                            </div>
+                                          ) : (
+                                            <>
+                                              <span>
+                                                {formattedDate(task.due)}
+                                              </span>
+                                              <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => {
+                                                  setIsEditingDueDate(true);
+                                                  const dueDate = task.due
+                                                    ? task.due.includes('T')
+                                                      ? task.due.split('T')[0]
+                                                      : task.due
+                                                    : '';
+                                                  setEditedDueDate(dueDate);
+                                                }}
+                                              >
+                                                <PencilIcon className="h-4 w-4 text-gray-500" />
+                                              </Button>
+                                            </>
+                                          )}
                                         </TableCell>
                                       </TableRow>
                                       <TableRow>

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -94,6 +94,7 @@ export const editTaskOnBackend = async ({
   wait,
   end,
   depends,
+  due,
 }: {
   email: string;
   encryptionSecret: string;
@@ -108,6 +109,7 @@ export const editTaskOnBackend = async ({
   wait: string;
   end: string;
   depends: string[];
+  due: string;
 }) => {
   const response = await fetch(`${backendURL}edit-task`, {
     method: 'POST',
@@ -124,6 +126,7 @@ export const editTaskOnBackend = async ({
       wait,
       end,
       depends,
+      due,
     }),
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION

Added due field editing functionality. Users can set task due dates using a DatePicker component.

**Backend:**
- Added `Due` field to `EditTaskRequestBody` model
- Updated `EditTaskHandler` to extract and pass due parameter  
- Modified `EditTaskInTaskwarrior` to execute `task modify due:value` command

**Frontend:**
- Added due parameter to `editTaskOnBackend` function
- Implemented editable UI for due field with DatePicker and save/cancel buttons
- Updated all `handleEditTaskOnBackend` calls to pass due value

- Contributes to: #166

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [x] Updated documentation, if needed

### Additional Notes
When users edit the due field, the backend executes `task <id> modify due:YYYY-MM-DDT00:00:00`. The DatePicker allows selecting dates, and the backend formats them to match Taskwarrior's expected format (same as wait field).

**Video Demo **

https://github.com/user-attachments/assets/653d6bab-af02-44a5-a6b8-9bd8e6f0c014


