### PR TITLE
fix: include EncryptionSecret in downloaded configuration file

### DIFF
--- a/frontend/src/components/HomeComponents/SetupGuide/utils.ts
+++ b/frontend/src/components/HomeComponents/SetupGuide/utils.ts
@@ -4,6 +4,7 @@ import { url } from '@/components/utils/URLs';
 export function exportConfigSetup(props: Props): string {
   return [
     'Configure Taskwarrior with these commands, run these commands one block at a time',
+    `task config sync.encryption_secret ${props.encryption_secret}`,
     `task config sync.server.origin ${url.containerOrigin}`,
     `task config sync.server.client_id ${props.uuid}`,
     'For more information about how this works, refer to the task-sync(5) manpage for details on how to configure the new sync implementation.',


### PR DESCRIPTION
Fixes #238

The Download Configuration button was generating a text file that was missing the `EncryptionSecret` command. This PR adds the missing `encryption_secret` configuration line to the `exportConfigSetup` function.

## Changes
- Added `task config sync.encryption_secret ${props.encryption_secret}` to the exported configuration in `frontend/src/components/HomeComponents/SetupGuide/utils.ts`

## Before
The downloaded configuration file only contained:
- ✅ Sync Server Origin
- ✅ Client ID
- ❌ Encryption Secret (missing)

## After  
The downloaded configuration file now contains all three required values:
- ✅ Encryption Secret
- ✅ Sync Server Origin
- ✅ Client ID

## Test plan
- [x] Identified the bug in the `exportConfigSetup` function
- [x] Added the missing encryption secret line
- [x] Verified the fix matches the UI display order
