### PR TITLE
feat: implement project selector dropdown and inline new project creation

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -1097,13 +1097,16 @@ export const Tasks = (
                                 <Select
                                   value={
                                     isCreatingNewProject
-                                      ? '__create__'
+                                      ? ''
                                       : newTask.project || ''
                                   }
                                   onValueChange={(value: string) => {
-                                    if (value === '__create__') {
+                                    if (value === '') {
+                                      // User selected "create new project" option
                                       setIsCreatingNewProject(true);
+                                      setNewTask({ ...newTask, project: '' });
                                     } else {
+                                      // User selected an existing project
                                       setIsCreatingNewProject(false);
                                       setNewTask({
                                         ...newTask,
@@ -1132,7 +1135,7 @@ export const Tasks = (
                                       </SelectItem>
                                     ))}
                                     <SelectItem
-                                      value="__create__"
+                                      value=""
                                       data-testid="project-option-create"
                                     >
                                       + Create new project…

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -475,7 +475,7 @@ describe('Tasks Component', () => {
     fireEvent.click(screen.getByRole('button', { name: /add task/i }));
 
     const projectSelect = await screen.findByTestId('project-select');
-    fireEvent.change(projectSelect, { target: { value: '__create__' } });
+    fireEvent.change(projectSelect, { target: { value: '' } }); // Empty string triggers "create new project" mode
 
     const newProjectInput =
       await screen.findByPlaceholderText('New project name');


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes made in this PR -->
This PR implements a project selection dropdown with an inline “Create New Project” option within the tasks view.
It allows users to select an existing project or quickly create a new one without navigating away.

- Updated the Project field in Add Task: replaced free-text input with a Select dropdown.
- Added isCreatingNewProject UI state to allow switching between selecting an existing project and creating a new one inline.
- Included “+ Create new project…” option in the dropdown, which reveals an input for entering a new project name.
- Compute uniqueProjects from IndexedDB tasks (deduplicated & alphabetically sorted).
- On manual sync, recompute project list from synced tasks so the dropdown reflects latest data.

Added two new tests in Tasks.test.tsx:
- lists existing projects + create-new option
- reveals input when selecting Create-new option
- All existing tests continue to pass

- Fixes: #204 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

<!-- Any additional info, screenshots, or context -->
<img width="1919" height="808" alt="Screenshot 2025-12-03 133943" src="https://github.com/user-attachments/assets/132542e4-ea70-4b21-bc8e-04faf1203740" />

