### PR TITLE
fix(tasks): resolve black screen when editing wait date field

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -1812,8 +1812,32 @@ export const Tasks = (
                                             <div className="flex items-center gap-2">
                                               <DatePicker
                                                 date={
-                                                  editedWaitDate
-                                                    ? new Date(editedWaitDate)
+                                                  editedWaitDate &&
+                                                  editedWaitDate !== ''
+                                                    ? (() => {
+                                                        try {
+                                                          const dateStr =
+                                                            editedWaitDate.includes(
+                                                              'T'
+                                                            )
+                                                              ? editedWaitDate.split(
+                                                                  'T'
+                                                                )[0]
+                                                              : editedWaitDate;
+                                                          const parsed =
+                                                            new Date(
+                                                              dateStr +
+                                                                'T00:00:00'
+                                                            );
+                                                          return isNaN(
+                                                            parsed.getTime()
+                                                          )
+                                                            ? undefined
+                                                            : parsed;
+                                                        } catch {
+                                                          return undefined;
+                                                        }
+                                                      })()
                                                     : undefined
                                                 }
                                                 onDateChange={(date) =>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes made in this PR -->

Replaced unsafe `new Date()` with safe date parsing in wait date DatePicker. Added error handling and validation to prevent RangeError crashes.

Fixes black screen bug caused by invalid date parsing.

- Fixes: #252

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
#### Video
https://github.com/user-attachments/assets/3bd9381a-e239-416b-8e94-83df40f4fc48
<!-- Any additional info, screenshots, or context -->
