### PR TITLE
fix: hide filter and action buttons on tablet screens to prevent UI o…

### DIFF
--- a/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
+++ b/frontend/src/components/HomeComponents/BottomBar/BottomBar.tsx
@@ -23,7 +23,7 @@ const BottomBar: React.FC<BottomBarProps> = ({
   setSelectedTag,
 }) => {
   return (
-    <header className="sm:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40">
+    <header className="lg:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40">
       {/* Nav Links */}
       <NavigationMenu className="mx-auto">
         <div className="flex space-x-4 mr-2">

--- a/frontend/src/components/HomeComponents/BottomBar/__tests__/__snapshots__/BottomBar.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/BottomBar/__tests__/__snapshots__/BottomBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BottomBar Component using Snapshot renders correctly with only one selected props: Bottom bar with only one selected props 1`] = `
 <DocumentFragment>
   <header
-    class="sm:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
+    class="lg:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
   >
     <nav
       aria-label="Main"
@@ -96,7 +96,7 @@ exports[`BottomBar Component using Snapshot renders correctly with only one sele
 exports[`BottomBar Component using Snapshot renders correctly with several selected props: Bottom bar with several selected props 1`] = `
 <DocumentFragment>
   <header
-    class="sm:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
+    class="lg:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
   >
     <nav
       aria-label="Main"
@@ -189,7 +189,7 @@ exports[`BottomBar Component using Snapshot renders correctly with several selec
 exports[`BottomBar Component using Snapshot renders correctly without selected props: Bottom bar without selected props 1`] = `
 <DocumentFragment>
   <header
-    class="sm:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
+    class="lg:hidden fixed bottom-0 w-full bg-white border-t-[1px] dark:border-b-slate-700 dark:bg-background shadow-lg flex justify-between items-center p-4 z-40"
   >
     <nav
       aria-label="Main"

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -896,7 +896,7 @@ export const Tasks = (
                       options={uniqueProjects}
                       selectedValues={selectedProjects}
                       onSelectionChange={setSelectedProjects}
-                      className="hidden sm:flex min-w-[140px]"
+                      className="hidden lg:flex min-w-[140px]"
                       icon={<Key lable="p" />}
                     />
                     <MultiSelectFilter
@@ -905,7 +905,7 @@ export const Tasks = (
                       options={status}
                       selectedValues={selectedStatuses}
                       onSelectionChange={setSelectedStatuses}
-                      className="hidden sm:flex min-w-[140px]"
+                      className="hidden lg:flex min-w-[140px]"
                       icon={<Key lable="s" />}
                     />
                     <MultiSelectFilter
@@ -914,7 +914,7 @@ export const Tasks = (
                       options={uniqueTags}
                       selectedValues={selectedTags}
                       onSelectionChange={setSelectedTags}
-                      className="hidden sm:flex min-w-[140px]"
+                      className="hidden lg:flex min-w-[140px]"
                       icon={<Key lable="t" />}
                     />
                     <div className="pr-2">
@@ -931,7 +931,7 @@ export const Tasks = (
                         uniqueProjects={uniqueProjects}
                       />
                     </div>
-                    <div className="hidden sm:flex flex-col items-end gap-2">
+                    <div className="flex flex-col items-end gap-2">
                       <Button
                         id="sync-task"
                         variant="outline"


### PR DESCRIPTION
Fixed UI breakage on tablet screens (iPad/Surface) where filter and action buttons were overflowing outside the container. Changed responsive breakpoints from `sm:` (640px) to `lg:` (1024px) for filter buttons, Add Task, and Sync buttons. BottomBar now shows on tablets (640px-1024px) like mobile devices, providing a clean mobile-friendly experience.

- Fixes: #221

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

**Changes Made:**
- Updated `BottomBar.tsx`: Changed `sm:hidden` to `lg:hidden` to show BottomBar on tablets
- Updated `Tasks.tsx`: Changed filter buttons (Projects, Status, Tags) from `sm:flex`

**Screenshots**
<img width="959" height="995" alt="Screenshot from 2025-12-09 21-35-55" src="https://github.com/user-attachments/assets/eb4c0e0e-947c-445f-9ac8-3fad1843b3ec" />
<img width="959" height="995" alt="Screenshot from 2025-12-09 21-36-35" src="https://github.com/user-attachments/assets/411a3e42-4119-4387-aca1-852ff653bbaf" />





