### PR TITLE
fix: navbar delete logic to prevent empty deletes

### DIFF
--- a/frontend/src/components/HomeComponents/Navbar/navbar-utils.ts
+++ b/frontend/src/components/HomeComponents/Navbar/navbar-utils.ts
@@ -54,23 +54,36 @@ export const handleLogout = async () => {
 };
 
 export const deleteAllTasks = async (props: Props) => {
-  const loadingToastId = toast.info(
-    `Deleting all tasks for ${props.email}...`,
-    {
-      position: 'bottom-left',
-      autoClose: false,
-      hideProgressBar: true,
-      closeOnClick: false,
-      pauseOnHover: true,
-      draggable: true,
-    }
-  );
+  const loadingToastId = toast.info(`Checking tasks for ${props.email}...`, {
+    position: 'bottom-left',
+    autoClose: false,
+    hideProgressBar: true,
+    closeOnClick: false,
+    pauseOnHover: true,
+    draggable: true,
+  });
 
   try {
+    // Count tasks first
+    const taskCount = await db.tasks.where('email').equals(props.email).count();
+
+    // If no tasks, show Red toast
+    if (taskCount === 0) {
+      toast.update(loadingToastId, {
+        render: `No tasks to delete for ${props.email}.`,
+        type: 'error',
+        autoClose: 3000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+      });
+      return;
+    }
     await db.tasks.where('email').equals(props.email).delete();
 
     toast.update(loadingToastId, {
-      render: `All tasks for ${props.email} deleted successfully!`,
+      render: `All ${taskCount} tasks for ${props.email} deleted successfully!`,
       type: 'success',
       autoClose: 3000,
       hideProgressBar: false,
@@ -79,7 +92,7 @@ export const deleteAllTasks = async (props: Props) => {
       draggable: true,
     });
 
-    console.log(`Deleted tasks for email: ${props.email}`);
+    console.log(`Deleted ${taskCount} tasks for email: ${props.email}`);
   } catch (error) {
     toast.update(loadingToastId, {
       render: `Error deleting tasks for ${props.email}: ${error}`,


### PR DESCRIPTION
### Description

This PR fixes the navbar "Delete all tasks" behavior by preventing the delete action when there are no tasks available for the selected user. A user-facing toast message is shown instead to clearly indicate that there are no tasks to delete.

- Fixes: #262 
### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

- Manual testing was performed to verify:
  - Delete works correctly when tasks exist
  - Delete is blocked and a toast is shown when no tasks exist
