### PR TITLE
fix: create new project button

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -145,16 +145,19 @@ export const AddTaskdialog = ({
                     }
                   />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent
+                  onWheel={(e) => e.stopPropagation()}
+                  className="max-h-60 overflow-y-auto"
+                >
+                  <SelectItem value="__CREATE_NEW__">
+                    + Create new project…
+                  </SelectItem>
                   <SelectItem value="__NONE__">No project</SelectItem>
                   {uniqueProjects.map((project: string) => (
                     <SelectItem key={project} value={project}>
                       {project}
                     </SelectItem>
                   ))}
-                  <SelectItem value="__CREATE_NEW__">
-                    + Create new project…
-                  </SelectItem>
                 </SelectContent>
               </Select>
 


### PR DESCRIPTION
### Description
previously while creating new task when you try to add new project +create new project button was not visible with alot of options in projects now i have fixed it buy adding scroll in selectcontent and moved the +create new project option to top 

### - Fixes: #263 

### video after fixes
[Screencast from 09-12-25 08:59:25 PM IST.webm](https://github.com/user-attachments/assets/bb0fec66-9a9c-477b-9f66-443288b54a53)

