### PR TITLE
feat: add annotations field to Add Task Panel

### DIFF
--- a/backend/controllers/add_task.go
+++ b/backend/controllers/add_task.go
@@ -47,6 +47,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 		priority := requestBody.Priority
 		dueDate := requestBody.DueDate
 		tags := requestBody.Tags
+		annotations := requestBody.Annotations
 
 		if description == "" {
 			http.Error(w, "Description is required, and cannot be empty!", http.StatusBadRequest)
@@ -62,7 +63,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Add Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Adding task: %s", description), uuid, "Add Task")
-				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, tags)
+				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, tags, annotations)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to add task: %v", err), uuid, "Add Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -2,14 +2,15 @@ package models
 
 // Request body for task related request handlers
 type AddTaskRequestBody struct {
-	Email            string   `json:"email"`
-	EncryptionSecret string   `json:"encryptionSecret"`
-	UUID             string   `json:"UUID"`
-	Description      string   `json:"description"`
-	Project          string   `json:"project"`
-	Priority         string   `json:"priority"`
-	DueDate          *string  `json:"due"`
-	Tags             []string `json:"tags"`
+	Email            string       `json:"email"`
+	EncryptionSecret string       `json:"encryptionSecret"`
+	UUID             string       `json:"UUID"`
+	Description      string       `json:"description"`
+	Project          string       `json:"project"`
+	Priority         string       `json:"priority"`
+	DueDate          *string      `json:"due"`
+	Tags             []string     `json:"tags"`
+	Annotations      []Annotation `json:"annotations"`
 }
 type ModifyTaskRequestBody struct {
 	Email            string   `json:"email"`

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -1,6 +1,7 @@
 package tw
 
 import (
+	"ccsync_backend/models"
 	"fmt"
 	"testing"
 )
@@ -41,7 +42,7 @@ func TestExportTasks(t *testing.T) {
 }
 
 func TestAddTaskToTaskwarrior(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", nil)
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", nil, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior failed: %v", err)
 	} else {
@@ -59,7 +60,7 @@ func TestCompleteTaskInTaskwarrior(t *testing.T) {
 }
 
 func TestAddTaskWithTags(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", []string{"work", "important"})
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", []string{"work", "important"}, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior with tags failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DatePicker } from '@/components/ui/date-picker';
@@ -35,6 +36,40 @@ export const AddTaskdialog = ({
   setIsCreatingNewProject,
   uniqueProjects = [],
 }: AddTaskDialogProps) => {
+  const [annotationInput, setAnnotationInput] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) {
+      setAnnotationInput('');
+    }
+  }, [isOpen]);
+
+  const handleAddAnnotation = () => {
+    if (annotationInput.trim()) {
+      const newAnnotation = {
+        entry: new Date().toISOString(),
+        description: annotationInput.trim(),
+      };
+      setNewTask({
+        ...newTask,
+        annotations: [...newTask.annotations, newAnnotation],
+      });
+      setAnnotationInput('');
+    }
+  };
+
+  const handleRemoveAnnotation = (annotationToRemove: {
+    entry: string;
+    description: string;
+  }) => {
+    setNewTask({
+      ...newTask,
+      annotations: newTask.annotations.filter(
+        (annotation) => annotation !== annotationToRemove
+      ),
+    });
+  };
+
   const handleAddTag = () => {
     if (tagInput && !newTask.tags.includes(tagInput, 0)) {
       setNewTask({ ...newTask, tags: [...newTask.tags, tagInput] });
@@ -228,6 +263,42 @@ export const AddTaskdialog = ({
               </div>
             )}
           </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="annotations" className="text-right">
+              Annotations
+            </Label>
+            <Input
+              id="annotations"
+              name="annotations"
+              placeholder="Add an annotation"
+              value={annotationInput}
+              onChange={(e) => setAnnotationInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddAnnotation()}
+              className="col-span-3"
+            />
+          </div>
+
+          <div className="mt-2">
+            {newTask.annotations.length > 0 && (
+              <div className="grid grid-cols-4 items-center">
+                <div> </div>
+                <div className="flex flex-wrap gap-2 col-span-3">
+                  {newTask.annotations.map((annotation, index) => (
+                    <Badge key={index}>
+                      <span>{annotation.description}</span>
+                      <button
+                        type="button"
+                        className="ml-2 text-red-500"
+                        onClick={() => handleRemoveAnnotation(annotation)}
+                      >
+                        ✖
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
         <DialogFooter>
           <Button
@@ -240,7 +311,9 @@ export const AddTaskdialog = ({
           <Button
             className="mb-1"
             variant="default"
-            onClick={() => onSubmit(newTask)}
+            onClick={() => {
+              onSubmit(newTask);
+            }}
           >
             Add Task
           </Button>

--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -1227,6 +1227,20 @@ export const TaskDialog = ({
                     </CopyToClipboard>
                   </TableCell>
                 </TableRow>
+                <TableRow>
+                  <TableCell>Annotations:</TableCell>
+                  <TableCell>
+                    {task.annotations && task.annotations.length > 0 ? (
+                      <span>
+                        {task.annotations
+                          .map((ann) => ann.description)
+                          .join(', ')}
+                      </span>
+                    ) : (
+                      <span>No Annotations</span>
+                    )}
+                  </TableCell>
+                </TableRow>
               </TableBody>
             </Table>
           </DialogDescription>

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -67,12 +67,13 @@ export const Tasks = (
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [idSortOrder, setIdSortOrder] = useState<'asc' | 'desc'>('asc');
 
-  const [newTask, setNewTask] = useState({
+  const [newTask, setNewTask] = useState<TaskFormData>({
     description: '',
     priority: '',
     project: '',
     due: '',
-    tags: [] as string[],
+    tags: [],
+    annotations: [],
   });
   const [isCreatingNewProject, setIsCreatingNewProject] = useState(false);
   const [isAddTaskOpen, setIsAddTaskOpen] = useState(false);
@@ -306,6 +307,7 @@ export const Tasks = (
         priority: task.priority,
         due: task.due || undefined,
         tags: task.tags,
+        annotations: task.annotations,
         backendURL: url.backendURL,
       });
 
@@ -316,6 +318,7 @@ export const Tasks = (
         project: '',
         due: '',
         tags: [],
+        annotations: [],
       });
       setIsAddTaskOpen(false);
     } catch (error) {

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -59,6 +59,7 @@ describe('AddTaskDialog Component', () => {
         project: '',
         due: '',
         tags: [],
+        annotations: [],
       },
       setNewTask: jest.fn(),
       tagInput: '',
@@ -219,6 +220,7 @@ describe('AddTaskDialog Component', () => {
       project: 'Work',
       due: '2024-12-25',
       tags: ['urgent'],
+      annotations: [],
     };
     render(<AddTaskdialog {...mockProps} />);
 

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/ReportView.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/ReportView.test.tsx
@@ -57,6 +57,7 @@ const createMockTask = (
     depends,
     rtype: 'mockRtype',
     recur: 'mockRecur',
+    annotations: [],
     email: 'mockEmail',
   };
 };

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/ReportsView.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/ReportsView.test.tsx
@@ -30,6 +30,7 @@ describe('ReportsView', () => {
     depends: [],
     rtype: '',
     recur: '',
+    annotations: [],
     email: 'test@example.com',
     ...overrides,
   });

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/TaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/TaskDialog.test.tsx
@@ -29,6 +29,7 @@ describe('TaskDialog Component', () => {
     depends: [],
     recur: '',
     rtype: '',
+    annotations: [],
   };
 
   const mockAllTasks: Task[] = [

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/UseEditTask.test.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/UseEditTask.test.ts
@@ -21,6 +21,7 @@ describe('useEditTask Hook', () => {
     depends: [],
     rtype: '',
     recur: '',
+    annotations: [],
     email: 'test@example.com',
   };
 

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
@@ -39,6 +39,7 @@ const createTask = (
   depends: [],
   rtype: '',
   recur: '',
+  annotations: [],
 });
 
 describe('sortTasks', () => {

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -43,6 +43,7 @@ export const addTaskToBackend = async ({
   priority,
   due,
   tags,
+  annotations,
   backendURL,
 }: {
   email: string;
@@ -53,6 +54,7 @@ export const addTaskToBackend = async ({
   priority: string;
   due?: string;
   tags: string[];
+  annotations: { entry: string; description: string }[];
   backendURL: string;
 }) => {
   const requestBody: any = {
@@ -69,6 +71,13 @@ export const addTaskToBackend = async ({
   if (due !== undefined && due !== '') {
     requestBody.due = due;
   }
+
+  // Add annotations to request body, filtering out empty descriptions
+  requestBody.annotations = annotations.filter(
+    (annotation) =>
+      annotation.description && annotation.description.trim() !== ''
+  );
+
   const response = await fetch(`${backendURL}add-task`, {
     method: 'POST',
     body: JSON.stringify(requestBody),

--- a/frontend/src/components/utils/__tests__/types.test.ts
+++ b/frontend/src/components/utils/__tests__/types.test.ts
@@ -54,6 +54,7 @@ describe('Task interface', () => {
       depends: ['123e4567', '123e4567'],
       rtype: 'any',
       recur: 'none',
+      annotations: [],
       email: 'test@example.com',
     };
 

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -15,6 +15,11 @@ export interface CopyButtonProps {
   label: string;
 }
 
+export interface Annotation {
+  entry: string;
+  description: string;
+}
+
 export interface Task {
   id: number;
   description: string;
@@ -33,6 +38,7 @@ export interface Task {
   depends: string[];
   rtype: string;
   recur: string;
+  annotations: Annotation[];
   email: string;
 }
 
@@ -94,6 +100,7 @@ export interface TaskFormData {
   project: string;
   due: string;
   tags: string[];
+  annotations: Annotation[];
 }
 
 export interface AddTaskDialogProps {


### PR DESCRIPTION
Description

This PR adds support for annotations when creating a task. An annotations input has been added to the Add Task dialog (following the existing tags UX), and the backend has been updated to correctly apply annotations using Taskwarrior after task creation. A read-only annotations section is also included in the Task Details view, and update test mocks to include annotations field for TypeScript compatibility

The scope is intentionally limited to adding the annotations field during task creation; editing annotations is out of scope.


Contributes to #188



### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

Annotations follow the same UI pattern as tags for consistency. Backend uses proper task ID retrieval for reliable annotation attachment to Taskwarrior.

** Demo video**


https://github.com/user-attachments/assets/a3c4bc93-eb96-4f11-998e-431033cd1c96


