### PR TITLE
fix(tasks): use uuid instead of id for dialog open condition

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -998,7 +998,7 @@ export const Tasks = (
                             selectedIndex={selectedIndex}
                             task={task}
                             isOpen={
-                              _isDialogOpen && _selectedTask?.id === task.id
+                              _isDialogOpen && _selectedTask?.uuid === task.uuid
                             }
                             onOpenChange={handleDialogOpenChange}
                             editState={editState}


### PR DESCRIPTION
### Description

Taskwarrior assigns id=0 to all completed and deleted tasks since they are removed from the active task list. Using task.id for the dialog's open condition caused multiple dialogs to open simultaneously when clicking on any non-pending task, resulting in flickering and blackout.

Replaced _selectedTask?.id === task.id with
_selectedTask?.uuid === task.uuid since uuid is unique for every task regardless of status.

Fixes: #271

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

**Video**:

https://github.com/user-attachments/assets/211d5106-83cf-47d0-a587-a2f9e501bf98


