### PR TITLE
Use environment variable for server port

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,20 @@
 
   if you want to run by `npm run dev`
 
+  ### Optional: Custom Backend Port
+
+  You can set a custom port for the backend server using the `CCSYNC_PORT` environment variable:
+
+  ```bash
+  CCSYNC_PORT="8081"
+  ```
+
+  Note:
+
+  `CCSYNC_PORT` only affects the port of the backend process itself, not the Docker port mapping, and is mainly intended for use outside of a containerized environment to avoid port conflicts.
+  If you are running the backend via Docker, the exposed ports are determined by the compose configuration. To use a different port in a Docker environment, you must manually update the docker-compose.yml file to adjust the container’s port mapping.
+  Also, if you change `CCSYNC_PORT`, remember to update `CONTAINER_ORIGIN` accordingly.
+
 - Run the application:
 
   ```bash

--- a/backend/main.go
+++ b/backend/main.go
@@ -58,6 +58,12 @@ func main() {
 	clientSecret := os.Getenv("CLIENT_SEC")
 	redirectURL := os.Getenv("REDIRECT_URL_DEV")
 
+	// Get port from environment or default to 8000
+	port := os.Getenv("CCSYNC_PORT")
+	if port == "" {
+		port = "8000"
+	}
+
 	// OAuth2 configuration
 	conf := &oauth2.Config{
 		ClientID:     clientID,
@@ -100,9 +106,9 @@ func main() {
 	mux.HandleFunc("/api/docs/", httpSwagger.WrapHandler)
 
 	go controllers.JobStatusManager()
-	utils.Logger.Info("Server started at :8000")
-	utils.Logger.Info("API documentation available at http://localhost:8000/api/docs/index.html")
-	if err := http.ListenAndServe(":8000", app.EnableCORS(mux)); err != nil {
+	utils.Logger.Infof("Server started at :%s", port)
+	utils.Logger.Infof("API documentation available at http://localhost:%s/api/docs/index.html", port)
+	if err := http.ListenAndServe(":"+port, app.EnableCORS(mux)); err != nil {
 		utils.Logger.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Summary

Add support for configuring the server port via the CCSYNC_PORT environment variable, with a default of 8000 when unset.

### Motivation

Needed for packaging ccsync on NixOS so the service port can be set to a custom value and avoid conflicts with other system services.