### PR TITLE
Add pin/unpin task feature

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -28,6 +28,8 @@ import {
   CopyIcon,
   Folder,
   PencilIcon,
+  Pin,
+  PinOff,
   Tag,
   Trash2Icon,
   XIcon,
@@ -59,6 +61,8 @@ export const TaskDialog = ({
   onMarkComplete,
   onMarkDeleted,
   isOverdue,
+  isPinned,
+  onTogglePin,
 }: EditTaskDialogProps) => {
   const handleDialogOpenChange = (open: boolean) => {
     if (open) {
@@ -129,28 +133,33 @@ export const TaskDialog = ({
             )}
           </TableCell>
           <TableCell className="py-2">
-            <Badge
-              className={
-                task.status === 'pending' && isOverdue(task.due)
-                  ? 'bg-orange-500 text-white'
-                  : ''
-              }
-              variant={
-                task.status === 'deleted'
-                  ? 'destructive'
+            <div className="flex items-center gap-1">
+              <Badge
+                className={
+                  task.status === 'pending' && isOverdue(task.due)
+                    ? 'bg-orange-500 text-white'
+                    : ''
+                }
+                variant={
+                  task.status === 'deleted'
+                    ? 'destructive'
+                    : task.status === 'completed'
+                      ? 'default'
+                      : 'secondary'
+                }
+              >
+                {task.status === 'pending' && isOverdue(task.due)
+                  ? 'O'
                   : task.status === 'completed'
-                    ? 'default'
-                    : 'secondary'
-              }
-            >
-              {task.status === 'pending' && isOverdue(task.due)
-                ? 'O'
-                : task.status === 'completed'
-                  ? 'C'
-                  : task.status === 'deleted'
-                    ? 'D'
-                    : 'P'}
-            </Badge>
+                    ? 'C'
+                    : task.status === 'deleted'
+                      ? 'D'
+                      : 'P'}
+              </Badge>
+              {isPinned && (
+                <Pin className="h-4 w-4 text-amber-500 fill-amber-500" />
+              )}
+            </div>
           </TableCell>
         </TableRow>
       </DialogTrigger>
@@ -1233,6 +1242,23 @@ export const TaskDialog = ({
 
         {/* Non-scrollable footer */}
         <DialogFooter className="flex flex-row justify-end pt-4">
+          <Button
+            variant="outline"
+            onClick={() => onTogglePin(task.uuid)}
+            className="mr-auto"
+          >
+            {isPinned ? (
+              <>
+                <PinOff className="h-4 w-4 mr-1" />
+                Unpin
+              </>
+            ) : (
+              <>
+                <Pin className="h-4 w-4 mr-1" />
+                Pin
+              </>
+            )}
+          </Button>
           {task.status == 'pending' ? (
             <Dialog>
               <DialogTrigger asChild className="mr-5">

--- a/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
+++ b/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
@@ -183,3 +183,53 @@ export const hashKey = (key: string, email: string): string => {
   }
   return Math.abs(hash).toString(36);
 };
+
+/**
+ * Get the set of pinned task UUIDs from localStorage
+ */
+export const getPinnedTasks = (email: string): Set<string> => {
+  const hashedKey = hashKey('pinnedTasks', email);
+  const stored = localStorage.getItem(hashedKey);
+  if (!stored) return new Set();
+  try {
+    return new Set(JSON.parse(stored));
+  } catch {
+    return new Set();
+  }
+};
+
+/**
+ * Save the set of pinned task UUIDs to localStorage
+ */
+export const savePinnedTasks = (
+  email: string,
+  pinnedUuids: Set<string>
+): void => {
+  const hashedKey = hashKey('pinnedTasks', email);
+  localStorage.setItem(hashedKey, JSON.stringify([...pinnedUuids]));
+};
+
+/**
+ * Toggle the pinned status of a task
+ * Returns the new pinned state
+ */
+export const togglePinnedTask = (email: string, taskUuid: string): boolean => {
+  const pinnedTasks = getPinnedTasks(email);
+  const isPinned = pinnedTasks.has(taskUuid);
+
+  if (isPinned) {
+    pinnedTasks.delete(taskUuid);
+  } else {
+    pinnedTasks.add(taskUuid);
+  }
+
+  savePinnedTasks(email, pinnedTasks);
+  return !isPinned;
+};
+
+/**
+ * Check if a task is pinned
+ */
+export const isTaskPinned = (email: string, taskUuid: string): boolean => {
+  return getPinnedTasks(email).has(taskUuid);
+};

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -133,4 +133,6 @@ export interface EditTaskDialogProps {
   onMarkComplete: (uuid: string) => void;
   onMarkDeleted: (uuid: string) => void;
   isOverdue: (due?: string) => boolean;
+  isPinned: boolean;
+  onTogglePin: (uuid: string) => void;
 }


### PR DESCRIPTION

### Description
This PR implements a **Pin Task** feature that allows users to pin important or frequently accessed tasks to keep them at the top of their task list.

- Fixes: #187 

### Changes Made
#### Frontend Changes:
- **New Utility Functions** (`tasks-utils.ts`):
  - `getPinnedTasks()` - Retrieves pinned task UUIDs from localStorage
  - `savePinnedTasks()` - Persists pinned tasks to localStorage
  - `togglePinnedTask()` - Toggles pin status for a task
  - `isTaskPinned()` - Checks if a task is pinned

- **UI Enhancements** (`TaskDialog.tsx`):
  - Added Pin/Unpin toggle button in the task dialog footer
  - Added amber-colored pin icon (📌) displayed to the right of the status badge for pinned tasks
  - Imported `Pin` and `PinOff` icons from lucide-react

- **State Management** (`Tasks.tsx`):
  - Added `pinnedTasks` state to track pinned tasks
  - Implemented `handleTogglePin()` handler for pin/unpin actions
  - Updated sorting logic with `sortWithPinnedAndOverdueOnTop()` to prioritize pinned tasks
  - Loads pinned tasks from localStorage on component mount

- **Type Definitions** (`types.ts`):
  - Extended `EditTaskDialogProps` interface with `isPinned` and `onTogglePin` properties


### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

<img width="1518" height="508" alt="image" src="https://github.com/user-attachments/assets/67f1e131-b8c7-4ec0-a46c-af672af21748" />
