### PR TITLE
fix(date-picker): remove modal prop to prevent focus trap conflict

### DIFF
--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -23,7 +23,7 @@ export function DatePicker({
   className,
 }: DatePickerProps) {
   return (
-    <Popover modal={true}>
+    <Popover>
       <PopoverTrigger asChild>
         <Button
           variant={'outline'}


### PR DESCRIPTION
### Description

- Removed modal={true} from Popover component in date-picker.tsx.
- Prevents nested focus trap conflict.
- Fixes page becoming unresponsive after clicking outside date picker.

**Root Cause:** The `modal={true}` prop on the Popover created a nested focus trap inside the Dialog's existing focus trap. When the calendar closed, both focus traps competed for control, leaving the page in an unresponsive state.

**Solution:** Removing `modal={true}` allows the Popover to work within the parent Dialog's focus trap instead of creating its own, eliminating the conflict.

Fixes: #279

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Self-Review

I've reviewed my changes and confirm:
- Date picker works correctly
- No breaking changes to existing functionality

#### Video:

https://github.com/user-attachments/assets/a0a2cfc5-edd3-4cca-9e74-3f98cc69b5fc