### PR TITLE
feat: add start field to task panel

### DIFF
--- a/backend/controllers/add_task.go
+++ b/backend/controllers/add_task.go
@@ -46,6 +46,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 		project := requestBody.Project
 		priority := requestBody.Priority
 		dueDate := requestBody.DueDate
+		start := requestBody.Start
 		tags := requestBody.Tags
 		annotations := requestBody.Annotations
 
@@ -63,7 +64,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Add Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Adding task: %s", description), uuid, "Add Task")
-				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, tags, annotations)
+				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, start, tags, annotations)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to add task: %v", err), uuid, "Add Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -9,6 +9,7 @@ type AddTaskRequestBody struct {
 	Project          string       `json:"project"`
 	Priority         string       `json:"priority"`
 	DueDate          *string      `json:"due"`
+	Start            string       `json:"start"`
 	Tags             []string     `json:"tags"`
 	Annotations      []Annotation `json:"annotations"`
 }

--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -10,7 +10,7 @@ import (
 )
 
 // add task to the user's tw client
-func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate string, tags []string, annotations []models.Annotation) error {
+func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start string, tags []string, annotations []models.Annotation) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -39,6 +39,9 @@ func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, p
 	}
 	if dueDate != "" {
 		cmdArgs = append(cmdArgs, "due:"+dueDate)
+	}
+	if start != "" {
+		cmdArgs = append(cmdArgs, "start:"+start)
 	}
 	// Add tags to the task
 	if len(tags) > 0 {

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -42,7 +42,7 @@ func TestExportTasks(t *testing.T) {
 }
 
 func TestAddTaskToTaskwarrior(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", nil, []models.Annotation{{Description: "note"}})
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", nil, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior failed: %v", err)
 	} else {
@@ -60,7 +60,7 @@ func TestCompleteTaskInTaskwarrior(t *testing.T) {
 }
 
 func TestAddTaskWithTags(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", []string{"work", "important"}, []models.Annotation{{Description: "note"}})
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", []string{"work", "important"}, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior with tags failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -228,6 +228,23 @@ export const AddTaskdialog = ({
               />
             </div>
           </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="start" className="text-right">
+              Start
+            </Label>
+            <div className="col-span-3">
+              <DatePicker
+                date={newTask.start ? new Date(newTask.start) : undefined}
+                onDateChange={(date) => {
+                  setNewTask({
+                    ...newTask,
+                    start: date ? format(date, 'yyyy-MM-dd') : '',
+                  });
+                }}
+                placeholder="Select a start date"
+              />
+            </div>
+          </div>
           <div className="grid grid-cols-8 items-center gap-4">
             <Label htmlFor="tags" className="text-right col-span-2">
               Tags

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -72,6 +72,7 @@ export const Tasks = (
     priority: '',
     project: '',
     due: '',
+    start: '',
     tags: [],
     annotations: [],
   });
@@ -306,6 +307,7 @@ export const Tasks = (
         project: task.project,
         priority: task.priority,
         due: task.due || undefined,
+        start: task.start || '',
         tags: task.tags,
         annotations: task.annotations,
         backendURL: url.backendURL,
@@ -317,6 +319,7 @@ export const Tasks = (
         priority: '',
         project: '',
         due: '',
+        start: '',
         tags: [],
         annotations: [],
       });

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -58,6 +58,7 @@ describe('AddTaskDialog Component', () => {
         priority: 'M',
         project: '',
         due: '',
+        start: '',
         tags: [],
         annotations: [],
       },
@@ -219,6 +220,7 @@ describe('AddTaskDialog Component', () => {
       priority: 'H',
       project: 'Work',
       due: '2024-12-25',
+      start: '',
       tags: ['urgent'],
       annotations: [],
     };

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -42,6 +42,7 @@ export const addTaskToBackend = async ({
   project,
   priority,
   due,
+  start,
   tags,
   annotations,
   backendURL,
@@ -53,6 +54,7 @@ export const addTaskToBackend = async ({
   project: string;
   priority: string;
   due?: string;
+  start: string;
   tags: string[];
   annotations: { entry: string; description: string }[];
   backendURL: string;
@@ -70,6 +72,11 @@ export const addTaskToBackend = async ({
   // Only include due if it's provided
   if (due !== undefined && due !== '') {
     requestBody.due = due;
+  }
+
+  // Only include start if it's provided
+  if (start !== undefined && start !== '') {
+    requestBody.start = start;
   }
 
   // Add annotations to request body, filtering out empty descriptions

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -99,6 +99,7 @@ export interface TaskFormData {
   priority: string;
   project: string;
   due: string;
+  start: string;
   tags: string[];
   annotations: Annotation[];
 }


### PR DESCRIPTION

Added start date field support to task creation, allowing users to set when a task begins.

- Backend: Added start field to AddTaskRequestBody model and AddTaskToTaskwarrior function
- Frontend: Added start date input field in task creation dialog

- Contributes to  #188 
### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
The start field follows the same pattern as other optional date fields (due, wait, entry). Empty strings are used to indicate when no start date is set, consistent with existing codebase conventions.

### Demo: 

https://github.com/user-attachments/assets/398a722c-c144-4df3-98b7-5617ed797746

