### PR TITLE
Fix task dialog blinking during edits

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -66,7 +66,9 @@ export const HomePage: React.FC = () => {
     }
 
     console.log('Setting up WebSocket with clientID:', userInfo.uuid);
-    const socketURL = `${url.backendURL.replace(/^http/, 'ws')}ws?clientID=${userInfo.uuid}`;
+    const socketURL = `${url.backendURL.replace(/^http/, 'ws')}ws?clientID=${
+      userInfo.uuid
+    }`;
     const socket = new WebSocket(socketURL);
 
     socket.onopen = () => console.log('WebSocket connected!');
@@ -76,7 +78,11 @@ export const HomePage: React.FC = () => {
       try {
         const data = JSON.parse(event.data);
         if (data.status === 'success') {
-          getTasks(userInfo.email, userInfo.encryption_secret, userInfo.uuid);
+          // Skip refresh for Edit Task to prevent dialog blinking
+          if (data.job !== 'Edit Task') {
+            getTasks(userInfo.email, userInfo.encryption_secret, userInfo.uuid);
+          }
+
           if (data.job === 'Add Task') {
             console.log('Task added successfully');
             toast.success('Task added successfully!', {


### PR DESCRIPTION
Skip WebSocket refresh for Edit Task operations
Prevents dialog from disappearing when editing fields

### Description
- Modified WebSocket handler to skip task list refresh for Edit Task operations
- Task dialog now stays open when editing fields (description, due date, tags, etc.)
- Other operations (Add, Complete, Delete) still refresh normally
- Fixes: #(issue_number_if_exists)

## Fixes : #286

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
- Only affects Edit Task WebSocket responses - all other functionality unchanged

## Demo Video : 

https://github.com/user-attachments/assets/19843e07-9594-438a-ae00-016bb2b874b0


