### PR TITLE
Hide broken Discord and Email link and update layout classes

### DIFF
--- a/frontend/src/components/LandingComponents/Contact/Contact.tsx
+++ b/frontend/src/components/LandingComponents/Contact/Contact.tsx
@@ -32,7 +32,8 @@ const contactList: ContactProps[] = [
     position: 'Check out our Github repository',
     url: url.githubRepoURL,
   },
-  {
+  // HIDING BROKEN LINKS TEMPORARILY
+  /* {
     icon: <AiOutlineDiscord size={45} />,
     name: 'Discord',
     position: 'Join us at Discord for discussions',
@@ -43,7 +44,8 @@ const contactList: ContactProps[] = [
     name: 'Email',
     position: 'Email us for any queries',
     url: '',
-  },
+  }, 
+  */
 ];
 
 const cardVariants = {
@@ -75,7 +77,7 @@ export const Contact = () => {
       <div
         data-testid="contact"
         ref={ref}
-        className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 gap-y-10"
+        className="flex flex-wrap justify-center gap-8 gap-y-10"
       >
         {contactList.map(({ icon, name, position, url }: ContactProps) => (
           <motion.div


### PR DESCRIPTION
### Description

This PR fixes a layout alignment issue in the "Contact Us" section and temporarily hides incomplete contact options to improve user experience.

**Changes made:**
1. **Hidden Broken Links:** Commented out the "Discord" and "Email" cards in the `contactList` array. These items had empty URL strings (`''`), which caused the page to reload or jump when clicked.
2. **Improved Layout:** Switched the container class from a fixed 4-column grid (`grid lg:grid-cols-4`) to a flexible centered layout (`flex flex-wrap justify-center`). This ensures the remaining two cards (Zulip and Github) are perfectly centered on the screen, rather than being stuck on the left side.

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

The switch to `flex-wrap` is future-proof; if the Discord and Email links are uncommented later, the layout will automatically adjust to center all 4 items again.

**Note to Maintainers:** I commented out the Discord and Email sections because their URLs were missing. If you have the valid invite links, let me know and I can update the `URLs` file and uncomment these sections.