### PR TITLE
Add recur field to task creation panel

### DIFF
--- a/backend/controllers/add_task.go
+++ b/backend/controllers/add_task.go
@@ -47,6 +47,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 		priority := requestBody.Priority
 		dueDate := requestBody.DueDate
 		start := requestBody.Start
+		recur := requestBody.Recur
 		tags := requestBody.Tags
 		annotations := requestBody.Annotations
 
@@ -64,7 +65,7 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 			Name: "Add Task",
 			Execute: func() error {
 				logStore.AddLog("INFO", fmt.Sprintf("Adding task: %s", description), uuid, "Add Task")
-				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, start, tags, annotations)
+				err := tw.AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDateStr, start, recur, tags, annotations)
 				if err != nil {
 					logStore.AddLog("ERROR", fmt.Sprintf("Failed to add task: %v", err), uuid, "Add Task")
 					return err

--- a/backend/models/request_body.go
+++ b/backend/models/request_body.go
@@ -10,6 +10,7 @@ type AddTaskRequestBody struct {
 	Priority         string       `json:"priority"`
 	DueDate          *string      `json:"due"`
 	Start            string       `json:"start"`
+	Recur            string       `json:"recur"`
 	Tags             []string     `json:"tags"`
 	Annotations      []Annotation `json:"annotations"`
 }

--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -10,7 +10,7 @@ import (
 )
 
 // add task to the user's tw client
-func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start string, tags []string, annotations []models.Annotation) error {
+func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, priority, dueDate, start, recur string, tags []string, annotations []models.Annotation) error {
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
@@ -42,6 +42,11 @@ func AddTaskToTaskwarrior(email, encryptionSecret, uuid, description, project, p
 	}
 	if start != "" {
 		cmdArgs = append(cmdArgs, "start:"+start)
+	}
+	// Note: Taskwarrior requires a due date to be set before recur can be set
+	// Only add recur if dueDate is also provided
+	if recur != "" && dueDate != "" {
+		cmdArgs = append(cmdArgs, "recur:"+recur)
 	}
 	// Add tags to the task
 	if len(tags) > 0 {

--- a/backend/utils/tw/taskwarrior_test.go
+++ b/backend/utils/tw/taskwarrior_test.go
@@ -42,7 +42,7 @@ func TestExportTasks(t *testing.T) {
 }
 
 func TestAddTaskToTaskwarrior(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", nil, []models.Annotation{{Description: "note"}})
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", "daily", nil, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior failed: %v", err)
 	} else {
@@ -60,7 +60,7 @@ func TestCompleteTaskInTaskwarrior(t *testing.T) {
 }
 
 func TestAddTaskWithTags(t *testing.T) {
-	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", []string{"work", "important"}, []models.Annotation{{Description: "note"}})
+	err := AddTaskToTaskwarrior("email", "encryption_secret", "clientId", "description", "", "H", "2025-03-03", "2025-03-01", "daily", []string{"work", "important"}, []models.Annotation{{Description: "note"}})
 	if err != nil {
 		t.Errorf("AddTaskToTaskwarrior with tags failed: %v", err)
 	} else {

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -245,6 +245,31 @@ export const AddTaskdialog = ({
               />
             </div>
           </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="recur" className="text-right">
+              Recur
+            </Label>
+            <div className="col-span-1 flex items-center">
+              <select
+                id="recur"
+                name="recur"
+                value={newTask.recur}
+                onChange={(e) =>
+                  setNewTask({
+                    ...newTask,
+                    recur: e.target.value,
+                  })
+                }
+                className="border rounded-md px-2 py-1 w-full bg-white text-black dark:bg-black dark:text-white transition-colors"
+              >
+                <option value="">None</option>
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+                <option value="yearly">Yearly</option>
+              </select>
+            </div>
+          </div>
           <div className="grid grid-cols-8 items-center gap-4">
             <Label htmlFor="tags" className="text-right col-span-2">
               Tags

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -73,6 +73,7 @@ export const Tasks = (
     project: '',
     due: '',
     start: '',
+    recur: '',
     tags: [],
     annotations: [],
   });
@@ -308,6 +309,7 @@ export const Tasks = (
         priority: task.priority,
         due: task.due || undefined,
         start: task.start || '',
+        recur: task.recur || '',
         tags: task.tags,
         annotations: task.annotations,
         backendURL: url.backendURL,
@@ -320,6 +322,7 @@ export const Tasks = (
         project: '',
         due: '',
         start: '',
+        recur: '',
         tags: [],
         annotations: [],
       });

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -59,6 +59,7 @@ describe('AddTaskDialog Component', () => {
         project: '',
         due: '',
         start: '',
+        recur: '',
         tags: [],
         annotations: [],
       },
@@ -221,6 +222,7 @@ describe('AddTaskDialog Component', () => {
       project: 'Work',
       due: '2024-12-25',
       start: '',
+      recur: '',
       tags: ['urgent'],
       annotations: [],
     };

--- a/frontend/src/components/HomeComponents/Tasks/hooks.ts
+++ b/frontend/src/components/HomeComponents/Tasks/hooks.ts
@@ -43,6 +43,7 @@ export const addTaskToBackend = async ({
   priority,
   due,
   start,
+  recur,
   tags,
   annotations,
   backendURL,
@@ -55,6 +56,7 @@ export const addTaskToBackend = async ({
   priority: string;
   due?: string;
   start: string;
+  recur: string;
   tags: string[];
   annotations: { entry: string; description: string }[];
   backendURL: string;
@@ -77,6 +79,11 @@ export const addTaskToBackend = async ({
   // Only include start if it's provided
   if (start !== undefined && start !== '') {
     requestBody.start = start;
+  }
+
+  // Only include recur if it's provided
+  if (recur !== undefined && recur !== '') {
+    requestBody.recur = recur;
   }
 
   // Add annotations to request body, filtering out empty descriptions

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -100,6 +100,7 @@ export interface TaskFormData {
   project: string;
   due: string;
   start: string;
+  recur: string;
   tags: string[];
   annotations: Annotation[];
 }


### PR DESCRIPTION
Add recur field to task creation panel , allowing users to set when a task begins.

### Description
Added a recur dropdown to the task creation dialog with options: daily, weekly, monthly, yearly. Users can now create recurring tasks. Backend validates that a due date is set before allowing recurrence (Taskwarrior requirement).

- Contributes to: #188

### Changes Made
- Added recur dropdown in task creation dialog
- Updated backend to handle recur field
- Added validation: recur only works when due date is set
- Updated all types and tests

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
Recur field requires a due date to be set first (Taskwarrior limitation). If no due date is provided, recur setting is ignored.

##Demo Video :

https://github.com/user-attachments/assets/daf4dfd2-2781-4f30-a9f3-f307ae28011e

