### PR TITLE
feat: add health check endpoint for docker

### DIFF
--- a/backend/controllers/healthcheck.go
+++ b/backend/controllers/healthcheck.go
@@ -1,0 +1,20 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "healthy",
+		"service": "ccsync-backend",
+	})
+}

--- a/backend/controllers/healthcheck_test.go
+++ b/backend/controllers/healthcheck_test.go
@@ -1,0 +1,56 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthCheckHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HealthCheckHandler)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	expected := "application/json"
+	if contentType := rr.Header().Get("Content-Type"); contentType != expected {
+		t.Errorf("handler returned wrong content type: got %v want %v", contentType, expected)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Errorf("could not parse response JSON: %v", err)
+	}
+
+	if response["status"] != "healthy" {
+		t.Errorf("expected status to be 'healthy', got %v", response["status"])
+	}
+
+	if response["service"] != "ccsync-backend" {
+		t.Errorf("expected service to be 'ccsync-backend', got %v", response["service"])
+	}
+}
+
+func TestHealthCheckHandlerMethodNotAllowed(t *testing.T) {
+	req, err := http.NewRequest("POST", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(HealthCheckHandler)
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusMethodNotAllowed {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusMethodNotAllowed)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -100,6 +100,8 @@ func main() {
 	mux.Handle("/delete-task", rateLimitedHandler(http.HandlerFunc(controllers.DeleteTaskHandler)))
 	mux.Handle("/sync/logs", rateLimitedHandler(http.HandlerFunc(controllers.SyncLogsHandler)))
 
+	mux.HandleFunc("/health", controllers.HealthCheckHandler)
+
 	mux.HandleFunc("/ws", controllers.WebSocketHandler)
 
 	// API documentation endpoint


### PR DESCRIPTION
Implements /health endpoint for Docker health checks and monitoring. Fixes missing health endpoint referenced in docker-compose.yml.

### Description
Adds missing /health endpoint that was referenced in docker-compose.yml but not implemented. Docker health checks were failing with 404 errors, preventing proper container monitoring and orchestration.

- Fixes: #296

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
Created `backend/controllers/health.go` with proper JSON response and method validation. Added comprehensive tests in `backend/controllers/health_test.go` covering both success and error cases. Registered endpoint in main.go without rate limiting as health checks need fast response times.


