### PR TITLE
fix(reports): correct date parsing and weekly range calculation

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/ReportChart.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/ReportChart.tsx
@@ -83,10 +83,21 @@ export const ReportChart: React.FC<ReportChartProps> = ({
           <Tooltip
             contentStyle={{ backgroundColor: '#333', border: 'none' }}
             labelClassName="text-white"
+            cursor={false}
           />
           <Legend wrapperClassName="text-white" />
-          <Bar dataKey="completed" fill="#E776CB" name="Completed" />
-          <Bar dataKey="ongoing" fill="#5FD9FA" name="Ongoing" />
+          <Bar
+            dataKey="completed"
+            fill="#E776CB"
+            name="Completed"
+            label={{ position: 'top', fill: 'white', fontSize: 12 }}
+          />
+          <Bar
+            dataKey="ongoing"
+            fill="#5FD9FA"
+            name="Ongoing"
+            label={{ position: 'top', fill: 'white', fontSize: 12 }}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ReportsViewProps } from '../../utils/types';
 import { getStartOfDay } from '../../utils/utils';
 import { ReportChart } from './ReportChart';
+import { parseTaskwarriorDate } from '../Tasks/tasks-utils';
 
 export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
   const now = new Date();
@@ -16,10 +17,13 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
   const countStatuses = (filterDate: Date) => {
     return tasks
       .filter((task) => {
-        const taskDateStr = task.modified || task.due;
+        const taskDateStr = task.end || task.due || task.entry;
         if (!taskDateStr) return false;
 
-        const modifiedDate = getStartOfDay(new Date(taskDateStr));
+        const parsedDate = parseTaskwarriorDate(taskDateStr);
+        if (!parsedDate) return false;
+
+        const modifiedDate = getStartOfDay(parsedDate);
         return modifiedDate >= filterDate;
       })
       .reduce(
@@ -36,9 +40,7 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
   };
 
   const dailyData = [{ name: 'Today', ...countStatuses(today) }];
-  const sevenDaysAgo = getStartOfDay(new Date());
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-  const weeklyData = [{ name: 'This Week', ...countStatuses(sevenDaysAgo) }];
+  const weeklyData = [{ name: 'This Week', ...countStatuses(startOfWeek) }];
   const monthlyData = [{ name: 'This Month', ...countStatuses(startOfMonth) }];
 
   return (

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -36,6 +36,7 @@ import {
   sortTasksById,
   getTimeSinceLastSync,
   hashKey,
+  parseTaskwarriorDate,
 } from './tasks-utils';
 import Pagination from './Pagination';
 import { url } from '@/components/utils/URLs';
@@ -120,14 +121,8 @@ export const Tasks = (
   const isOverdue = (due?: string) => {
     if (!due) return false;
 
-    const parsed = new Date(
-      due.replace(
-        /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/,
-        '$1-$2-$3T$4:$5:$6Z'
-      )
-    );
-
-    const dueDate = new Date(parsed);
+    const dueDate = parseTaskwarriorDate(due);
+    if (!dueDate) return false;
     dueDate.setHours(0, 0, 0, 0);
 
     const today = new Date();

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/ReportView.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/ReportView.test.tsx
@@ -23,20 +23,25 @@ const createMockTask = (
     depends = ['depends1', 'depends2'],
   } = overrides;
 
-  const getDateForOffset = (offset: DateOffset): Date => {
+  const getDateForOffset = (offset: DateOffset): string => {
+    let date: Date;
     switch (offset) {
       case 'dailyData':
-        return mockToday;
+        date = mockToday;
+        break;
       case 'weeklyData':
-        // Calcul du début de la semaine (dimanche)
         const startOfWeek = new Date(mockToday);
         startOfWeek.setUTCDate(
           startOfWeek.getUTCDate() - startOfWeek.getUTCDay()
         );
-        return startOfWeek;
+        date = startOfWeek;
+        break;
       case 'monthlyData':
-        return new Date(mockToday.getUTCFullYear(), mockToday.getUTCMonth(), 1);
+        date = new Date(mockToday.getUTCFullYear(), mockToday.getUTCMonth(), 1);
+        break;
     }
+    // Return Taskwarrior format: YYYYMMDDTHHMMSSZ
+    return date.toISOString().replace(/[-:]/g, '').replace('.000', '');
   };
 
   return {
@@ -48,12 +53,12 @@ const createMockTask = (
     uuid: `mockUuid-${id}`,
     urgency: 1,
     priority: 'mockPriority',
-    due: 'mockDue',
+    due: status === 'pending' ? getDateForOffset(dateOffset) : '',
     start: 'mockStart',
-    end: 'mockEnd',
-    entry: 'mockEntry',
+    end: status === 'completed' ? getDateForOffset(dateOffset) : '',
+    entry: getDateForOffset(dateOffset),
     wait: 'mockWait',
-    modified: getDateForOffset(dateOffset).toISOString(),
+    modified: '',
     depends,
     rtype: 'mockRtype',
     recur: 'mockRecur',

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
@@ -12,6 +12,7 @@ import {
   bulkMarkTasksAsDeleted,
   getTimeSinceLastSync,
   hashKey,
+  parseTaskwarriorDate,
 } from '../tasks-utils';
 import { Task } from '@/components/utils/types';
 
@@ -591,5 +592,25 @@ describe('bulkMarkTasksAsDeleted', () => {
     );
 
     expect(result).toBe(false);
+  });
+});
+
+describe('parseTaskwarriorDate', () => {
+  it('parses Taskwarrior date format correctly', () => {
+    const result = parseTaskwarriorDate('20241215T130002Z');
+    expect(result).toEqual(new Date('2024-12-15T13:00:02Z'));
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseTaskwarriorDate('')).toBeNull();
+  });
+
+  it('returns null for invalid date format', () => {
+    expect(parseTaskwarriorDate('invalid-date')).toBeNull();
+  });
+
+  it('handles ISO format gracefully', () => {
+    const result = parseTaskwarriorDate('20241215T130002Z');
+    expect(result).toBeInstanceOf(Date);
   });
 });

--- a/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
+++ b/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
@@ -182,6 +182,23 @@ export const formattedDate = (dateString: string) => {
   }
 };
 
+export const parseTaskwarriorDate = (dateString: string) => {
+  // Taskwarrior date format: YYYYMMDDTHHMMSSZ
+
+  if (!dateString) return null;
+
+  const year = dateString.substring(0, 4);
+  const month = dateString.substring(4, 6);
+  const day = dateString.substring(6, 8);
+  const hour = dateString.substring(9, 11);
+  const min = dateString.substring(11, 13);
+  const sec = dateString.substring(13, 15);
+  const parsed = `${year}-${month}-${day}T${hour}:${min}:${sec}Z`;
+
+  const date = new Date(parsed);
+  return isNaN(date.getTime()) ? null : date;
+};
+
 export const sortTasksById = (tasks: Task[], order: 'asc' | 'desc') => {
   return tasks.sort((a, b) => {
     if (order === 'asc') {


### PR DESCRIPTION
### Description

- Add parseTaskwarriorDate utility for Taskwarrior date format (YYYYMMDDTHHMMSSZ)
- Fix weekly report to use start of week instead of last 7 days
- Use end date for completed tasks instead of modified date
- Use entry date as fallback for pending tasks without due date
- Add count labels on chart bars for better visibility
- Refactor isOverdue to use shared date parsing utility

- Fixes: #322 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Video:
https://github.com/user-attachments/assets/a37b0659-8627-465e-9320-48a57d878021


