### PR TITLE
feat(reports): add "Overdue" as third category in Reports charts

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/ReportChart.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/ReportChart.tsx
@@ -98,6 +98,12 @@ export const ReportChart: React.FC<ReportChartProps> = ({
             name="Ongoing"
             label={{ position: 'top', fill: 'white', fontSize: 12 }}
           />
+          <Bar
+            dataKey="overdue"
+            fill="#F33434"
+            name="Overdue"
+            label={{ position: 'top', fill: 'white', fontSize: 12 }}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ReportsViewProps } from '../../utils/types';
 import { getStartOfDay } from '../../utils/utils';
 import { ReportChart } from './ReportChart';
-import { parseTaskwarriorDate } from '../Tasks/tasks-utils';
+import { parseTaskwarriorDate, isOverdue } from '../Tasks/tasks-utils';
 
 export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
   const now = new Date();
@@ -14,6 +14,7 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
   const startOfMonth = getStartOfDay(
     new Date(now.getFullYear(), now.getMonth(), 1)
   );
+
   const countStatuses = (filterDate: Date) => {
     return tasks
       .filter((task) => {
@@ -31,11 +32,15 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
           if (task.status === 'completed') {
             acc.completed += 1;
           } else if (task.status === 'pending') {
-            acc.ongoing += 1;
+            if (isOverdue(task.due)) {
+              acc.overdue += 1;
+            } else {
+              acc.ongoing += 1;
+            }
           }
           return acc;
         },
-        { completed: 0, ongoing: 0 }
+        { completed: 0, ongoing: 0, overdue: 0 }
       );
   };
 

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -36,7 +36,7 @@ import {
   sortTasksById,
   getTimeSinceLastSync,
   hashKey,
-  parseTaskwarriorDate,
+  isOverdue,
 } from './tasks-utils';
 import Pagination from './Pagination';
 import { url } from '@/components/utils/URLs';
@@ -117,19 +117,6 @@ export const Tasks = (
   } = useEditTask(_selectedTask);
 
   // Handler for dialog open/close
-
-  const isOverdue = (due?: string) => {
-    if (!due) return false;
-
-    const dueDate = parseTaskwarriorDate(due);
-    if (!dueDate) return false;
-    dueDate.setHours(0, 0, 0, 0);
-
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    return dueDate < today;
-  };
 
   const debouncedSearch = debounce((value: string) => {
     setDebouncedTerm(value);

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/ReportChart.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/ReportChart.test.tsx
@@ -27,7 +27,7 @@ jest.mock('../report-download-utils', () => ({
 }));
 
 describe('ReportChart', () => {
-  const mockData = [{ name: 'Today', completed: 5, ongoing: 3 }];
+  const mockData = [{ name: 'Today', completed: 5, ongoing: 3, overdue: 2 }];
 
   const defaultProps = {
     data: mockData,
@@ -85,6 +85,15 @@ describe('ReportChart', () => {
       const ongoingBar = screen.getByTestId('bar-ongoing');
       expect(ongoingBar).toHaveAttribute('data-fill', '#5FD9FA');
       expect(ongoingBar).toHaveAttribute('data-name', 'Ongoing');
+    });
+
+    it('displays overdue bar with correct color', () => {
+      render(<ReportChart {...defaultProps} />);
+
+      const overdueBar = screen.getByTestId('bar-overdue');
+
+      expect(overdueBar).toHaveAttribute('data-fill', '#F33434');
+      expect(overdueBar).toHaveAttribute('data-name', 'Overdue');
     });
 
     it('renders chart axes', () => {

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportChart.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportChart.test.tsx.snap
@@ -128,6 +128,11 @@ exports[`ReportChart Component using Snapshot renders correctly with one data en
           data-name="Ongoing"
           data-testid="bar-ongoing"
         />
+        <div
+          data-fill="#F33434"
+          data-name="Overdue"
+          data-testid="bar-overdue"
+        />
       </div>
     </div>
   </div>
@@ -261,6 +266,11 @@ exports[`ReportChart Component using Snapshot renders correctly with several dat
           data-fill="#5FD9FA"
           data-name="Ongoing"
           data-testid="bar-ongoing"
+        />
+        <div
+          data-fill="#F33434"
+          data-name="Overdue"
+          data-testid="bar-overdue"
         />
       </div>
     </div>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportView.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportView.test.tsx.snap
@@ -116,6 +116,9 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             <span>
               ongoing: 1 
             </span>
+            <span>
+              overdue: 0 
+            </span>
           </div>
           <div
             data-stroke="#555"
@@ -151,6 +154,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>
@@ -267,6 +276,9 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             <span>
               ongoing: 1 
             </span>
+            <span>
+              overdue: 0 
+            </span>
           </div>
           <div
             data-stroke="#555"
@@ -302,6 +314,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>
@@ -418,6 +436,9 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             <span>
               ongoing: 1 
             </span>
+            <span>
+              overdue: 0 
+            </span>
           </div>
           <div
             data-stroke="#555"
@@ -453,6 +474,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only one ta
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>
@@ -578,6 +605,9 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
             <span>
               ongoing: 1 
             </span>
+            <span>
+              overdue: 0 
+            </span>
           </div>
           <div
             data-stroke="#555"
@@ -613,6 +643,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>
@@ -727,7 +763,10 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
               completed: 2 
             </span>
             <span>
-              ongoing: 2 
+              ongoing: 1 
+            </span>
+            <span>
+              overdue: 1 
             </span>
           </div>
           <div
@@ -764,6 +803,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>
@@ -878,7 +923,10 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
               completed: 4 
             </span>
             <span>
-              ongoing: 4 
+              ongoing: 1 
+            </span>
+            <span>
+              overdue: 3 
             </span>
           </div>
           <div
@@ -915,6 +963,12 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
             data-data-key="ongoing"
             data-fill="#5FD9FA"
             data-name="Ongoing"
+            data-testid="Bar"
+          />
+          <div
+            data-data-key="overdue"
+            data-fill="#F33434"
+            data-name="Overdue"
             data-testid="Bar"
           />
         </div>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/tasks-utils.test.ts
@@ -13,6 +13,7 @@ import {
   getTimeSinceLastSync,
   hashKey,
   parseTaskwarriorDate,
+  isOverdue,
 } from '../tasks-utils';
 import { Task } from '@/components/utils/types';
 
@@ -612,5 +613,39 @@ describe('parseTaskwarriorDate', () => {
   it('handles ISO format gracefully', () => {
     const result = parseTaskwarriorDate('20241215T130002Z');
     expect(result).toBeInstanceOf(Date);
+  });
+});
+
+describe('isOverdue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-11-11T10:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns false for undefined due date', () => {
+    expect(isOverdue(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string due date', () => {
+    expect(isOverdue('')).toBe(false);
+  });
+
+  it('returns false for future due date', () => {
+    expect(isOverdue('20251215T130002Z')).toBe(false);
+  });
+
+  it('returns true for past due date', () => {
+    expect(isOverdue('20251015T130002Z')).toBe(true);
+  });
+
+  it('returns false for today due date', () => {
+    expect(isOverdue('20251111T130002Z')).toBe(false);
+  });
+
+  it('returns false for invalid date format', () => {
+    expect(isOverdue('invalid-date')).toBe(false);
   });
 });

--- a/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
+++ b/frontend/src/components/HomeComponents/Tasks/tasks-utils.ts
@@ -199,6 +199,19 @@ export const parseTaskwarriorDate = (dateString: string) => {
   return isNaN(date.getTime()) ? null : date;
 };
 
+export const isOverdue = (due?: string) => {
+  if (!due) return false;
+
+  const dueDate = parseTaskwarriorDate(due);
+  if (!dueDate) return false;
+  dueDate.setHours(0, 0, 0, 0);
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return dueDate < today;
+};
+
 export const sortTasksById = (tasks: Task[], order: 'asc' | 'desc') => {
   return tasks.sort((a, b) => {
     if (order === 'asc') {


### PR DESCRIPTION
### Description

- Add isOverdue utility function to tasks-utils.ts for shared usage
- Update ReportsView to categorize pending tasks with past due dates as overdue
- Add overdue bar (red #F33434) to ReportChart component
- Update Tasks.tsx to import isOverdue from shared utility
- Add comprehensive test coverage for overdue categorization

Categorization logic:
- status === 'completed' -> Completed (pink)
- status === 'pending' && due < today -> Overdue (red)
- status === 'pending' && (due >= today || no due) -> Ongoing (blue)

Fixes: #341 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Video:

https://github.com/user-attachments/assets/5619a7d1-83a4-435d-9c8b-75651ca8241e