### PR TITLE
feat: add datetime picker for due field in TaskDialog

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -73,6 +73,12 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		due, err = utils.ConvertISOToTaskwarriorFormat(due)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid due date format: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		logStore := models.GetLogStore()
 		job := Job{
 			Name: "Edit Task",

--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -266,7 +266,7 @@ export const TaskDialog = ({
                   <TableCell>
                     {editState.isEditingDueDate ? (
                       <div className="flex items-center gap-2">
-                        <DatePicker
+                        <DateTimePicker
                           date={
                             editState.editedDueDate &&
                             editState.editedDueDate !== ''
@@ -274,11 +274,9 @@ export const TaskDialog = ({
                                   try {
                                     const dateStr =
                                       editState.editedDueDate.includes('T')
-                                        ? editState.editedDueDate.split('T')[0]
-                                        : editState.editedDueDate;
-                                    const parsed = new Date(
-                                      dateStr + 'T00:00:00'
-                                    );
+                                        ? editState.editedDueDate
+                                        : editState.editedDueDate + 'T00:00:00';
+                                    const parsed = new Date(dateStr);
                                     return isNaN(parsed.getTime())
                                       ? undefined
                                       : parsed;
@@ -288,14 +286,16 @@ export const TaskDialog = ({
                                 })()
                               : undefined
                           }
-                          onDateChange={(date) =>
+                          onDateTimeChange={(date, hasTime) =>
                             onUpdateState({
                               editedDueDate: date
-                                ? format(date, 'yyyy-MM-dd')
+                                ? hasTime
+                                  ? date.toISOString()
+                                  : format(date, 'yyyy-MM-dd')
                                 : '',
                             })
                           }
-                          placeholder="Select due date"
+                          placeholder="Select due date and time"
                         />
                         <Button
                           variant="ghost"
@@ -332,11 +332,7 @@ export const TaskDialog = ({
                           onClick={() => {
                             onUpdateState({
                               isEditingDueDate: true,
-                              editedDueDate: task.due
-                                ? task.due.includes('T')
-                                  ? task.due.split('T')[0]
-                                  : task.due
-                                : '',
+                              editedDueDate: task.due || '',
                             });
                           }}
                         >

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -1104,7 +1104,7 @@ describe('Tasks Component', () => {
   test.each([
     ['Wait', 'Wait:', 'Pick a date'],
     ['End', 'End:', 'Select end date'],
-    ['Due', 'Due:', 'Select due date'],
+    ['Due', 'Due:', 'Select due date and time'],
     ['Start', 'Start:', 'Select start date and time'],
     ['Entry', 'Entry:', 'Pick a date'],
   ])('shows red when task %s date is edited', async (_, label, placeholder) => {


### PR DESCRIPTION
Add DateTimePicker for due field in TaskDialog to allow users to select both date and time instead of just date.

Contributes: #326

**Checklist**
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

Additional Notes
This follows the same pattern as  start field PR. Users can now pick specific times for due dates, not just dates.

<img width="750" height="639" alt="Screenshot from 2025-12-30 21-44-26" src="https://github.com/user-attachments/assets/1d004dba-3e14-4e5b-aa3e-3fda1bb1d483" />
<img width="750" height="350" alt="Screenshot from 2025-12-30 21-44-06" src="https://github.com/user-attachments/assets/56a53f76-f055-448d-a9dd-5d7686b0d16b" />
