### PR TITLE
Add datetime picker for end field in TaskDialog

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -79,6 +79,12 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		end, err = utils.ConvertISOToTaskwarriorFormat(end)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid end date format: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		logStore := models.GetLogStore()
 		job := Job{
 			Name: "Edit Task",

--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -432,7 +432,7 @@ export const TaskDialog = ({
                   <TableCell>
                     {editState.isEditingEndDate ? (
                       <div className="flex items-center gap-2">
-                        <DatePicker
+                        <DateTimePicker
                           date={
                             editState.editedEndDate &&
                             editState.editedEndDate !== ''
@@ -440,11 +440,9 @@ export const TaskDialog = ({
                                   try {
                                     const dateStr =
                                       editState.editedEndDate.includes('T')
-                                        ? editState.editedEndDate.split('T')[0]
-                                        : editState.editedEndDate;
-                                    const parsed = new Date(
-                                      dateStr + 'T00:00:00'
-                                    );
+                                        ? editState.editedEndDate
+                                        : editState.editedEndDate + 'T00:00:00';
+                                    const parsed = new Date(dateStr);
                                     return isNaN(parsed.getTime())
                                       ? undefined
                                       : parsed;
@@ -454,14 +452,16 @@ export const TaskDialog = ({
                                 })()
                               : undefined
                           }
-                          onDateChange={(date) =>
+                          onDateTimeChange={(date, hasTime) =>
                             onUpdateState({
                               editedEndDate: date
-                                ? format(date, 'yyyy-MM-dd')
+                                ? hasTime
+                                  ? date.toISOString()
+                                  : format(date, 'yyyy-MM-dd')
                                 : '',
                             })
                           }
-                          placeholder="Select end date"
+                          placeholder="Select end date and time"
                         />
                         <Button
                           variant="ghost"
@@ -498,11 +498,7 @@ export const TaskDialog = ({
                           onClick={() => {
                             onUpdateState({
                               isEditingEndDate: true,
-                              editedEndDate: task.end
-                                ? task.end.includes('T')
-                                  ? task.end.split('T')[0]
-                                  : task.end
-                                : '',
+                              editedEndDate: task.end || '',
                             });
                           }}
                         >

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -1103,7 +1103,7 @@ describe('Tasks Component', () => {
 
   test.each([
     ['Wait', 'Wait:', 'Pick a date'],
-    ['End', 'End:', 'Select end date'],
+    ['End', 'End:', 'Select end date and time'],
     ['Due', 'Due:', 'Select due date and time'],
     ['Start', 'Start:', 'Select start date and time'],
     ['Entry', 'Entry:', 'Pick a date'],


### PR DESCRIPTION
Added DateTimePicker component to the end field in TaskDialog, allowing users to select both date and time instead of date-only. Updated backend to handle ISO datetime format conversion and updated tests accordingly.

Contributes: #326

**Checklist**
- [x] Ran npx prettier --write . (for formatting)
- [x] Ran gofmt -w . (for Go backend)
 - [x] Ran npm test (for JS/TS testing)
 - [x] Added unit tests, if applicable
- [x]  Verified all tests pass
- [ ]  Updated documentation, if needed

**Additional Notes**
this follows the same pattern as start and due fields. Frontend uses DateTimePicker with hasTime parameter for format selection (ISO vs YYYY-MM-DD). Backend converts ISO format to Taskwarrior format. 

<img width="600" height="600" alt="Screenshot from 2025-12-31 14-20-16" src="https://github.com/user-attachments/assets/e52b7154-3da8-4141-855f-c94f6a599eba" />
<img width="600" height="600" alt="Screenshot from 2025-12-31 14-21-02" src="https://github.com/user-attachments/assets/9a74b5a7-cc0d-4803-9835-1e734d1d5098" />

