### PR TITLE
Add datetime picker for entry field in TaskDialog

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -85,6 +85,12 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		entry, err = utils.ConvertISOToTaskwarriorFormat(entry)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid entry date format: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		logStore := models.GetLogStore()
 		job := Job{
 			Name: "Edit Task",

--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -1122,7 +1122,7 @@ export const TaskDialog = ({
                   <TableCell>
                     {editState.isEditingEntryDate ? (
                       <div className="flex items-center gap-2">
-                        <DatePicker
+                        <DateTimePicker
                           date={
                             editState.editedEntryDate &&
                             editState.editedEntryDate !== ''
@@ -1131,13 +1131,10 @@ export const TaskDialog = ({
                                     // Handle YYYY-MM-DD format
                                     const dateStr =
                                       editState.editedEntryDate.includes('T')
-                                        ? editState.editedEntryDate.split(
-                                            'T'
-                                          )[0]
-                                        : editState.editedEntryDate;
-                                    const parsed = new Date(
-                                      dateStr + 'T00:00:00'
-                                    );
+                                        ? editState.editedEntryDate
+                                        : editState.editedEntryDate +
+                                          'T00:00:00';
+                                    const parsed = new Date(dateStr);
                                     return isNaN(parsed.getTime())
                                       ? undefined
                                       : parsed;
@@ -1147,13 +1144,16 @@ export const TaskDialog = ({
                                 })()
                               : undefined
                           }
-                          onDateChange={(date) =>
+                          onDateTimeChange={(date, hasTime) =>
                             onUpdateState({
                               editedEntryDate: date
-                                ? format(date, 'yyyy-MM-dd')
+                                ? hasTime
+                                  ? date.toISOString()
+                                  : format(date, 'yyyy-MM-dd')
                                 : '',
                             })
                           }
+                          placeholder="Select entry date and time"
                         />
 
                         <Button
@@ -1174,12 +1174,8 @@ export const TaskDialog = ({
                           aria-label="cancel"
                           onClick={() =>
                             onUpdateState({
+                              editedEntryDate: task.entry || '',
                               isEditingEntryDate: false,
-                              editedEntryDate: task.entry
-                                ? task.entry.includes('T')
-                                  ? task.entry.split('T')[0]
-                                  : task.entry
-                                : '',
                             })
                           }
                         >
@@ -1193,16 +1189,12 @@ export const TaskDialog = ({
                           variant="ghost"
                           size="icon"
                           aria-label="edit"
-                          onClick={() =>
+                          onClick={() => {
                             onUpdateState({
                               isEditingEntryDate: true,
-                              editedEntryDate: task.entry
-                                ? task.entry.includes('T')
-                                  ? task.entry.split('T')[0]
-                                  : task.entry
-                                : '',
-                            })
-                          }
+                              editedEntryDate: task.entry || '',
+                            });
+                          }}
                         >
                           <PencilIcon className="h-4 w-4 text-gray-500" />
                         </Button>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -1105,7 +1105,7 @@ describe('Tasks Component', () => {
     ['End', 'End:', 'Select end date and time'],
     ['Due', 'Due:', 'Select due date and time'],
     ['Start', 'Start:', 'Select start date and time'],
-    ['Entry', 'Entry:', 'Pick a date'],
+    ['Entry', 'Entry:', 'Select entry date and time'],
   ])('shows red when task %s date is edited', async (_, label, placeholder) => {
     render(<Tasks {...mockProps} />);
 


### PR DESCRIPTION
### Description
Add DateTimePicker component to the entry field in TaskDialog to allow users to select both date and time instead of date-only selection.

- Contributes: #326

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

<img width="773" height="436" alt="Screenshot from 2025-12-31 21-29-45" src="https://github.com/user-attachments/assets/b11bbb83-70a5-4f97-abd5-bd4c3d9aa537" />
<img width="633" height="620" alt="Screenshot from 2025-12-31 21-28-56" src="https://github.com/user-attachments/assets/477d1fc2-b626-4b96-b1b7-ecc175cacfa3" />

