### PR TITLE
feat(TaskDialog): add datetime picker for wait field

### DIFF
--- a/backend/controllers/edit_task.go
+++ b/backend/controllers/edit_task.go
@@ -91,6 +91,12 @@ func EditTaskHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		wait, err = utils.ConvertISOToTaskwarriorFormat(wait)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid wait date format: %v", err), http.StatusBadRequest)
+			return
+		}
+
 		logStore := models.GetLogStore()
 		job := Job{
 			Name: "Edit Task",

--- a/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/TaskDialog.tsx
@@ -1,7 +1,6 @@
 import { EditTaskDialogProps } from '../../utils/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { DatePicker } from '@/components/ui/date-picker';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 import {
   Dialog,
@@ -513,7 +512,7 @@ export const TaskDialog = ({
                   <TableCell>
                     {editState.isEditingWaitDate ? (
                       <div className="flex items-center gap-2">
-                        <DatePicker
+                        <DateTimePicker
                           date={
                             editState.editedWaitDate &&
                             editState.editedWaitDate !== ''
@@ -521,11 +520,10 @@ export const TaskDialog = ({
                                   try {
                                     const dateStr =
                                       editState.editedWaitDate.includes('T')
-                                        ? editState.editedWaitDate.split('T')[0]
-                                        : editState.editedWaitDate;
-                                    const parsed = new Date(
-                                      dateStr + 'T00:00:00'
-                                    );
+                                        ? editState.editedWaitDate
+                                        : editState.editedWaitDate +
+                                          'T00:00:00';
+                                    const parsed = new Date(dateStr);
                                     return isNaN(parsed.getTime())
                                       ? undefined
                                       : parsed;
@@ -535,13 +533,16 @@ export const TaskDialog = ({
                                 })()
                               : undefined
                           }
-                          onDateChange={(date) =>
+                          onDateTimeChange={(date, hasTime) =>
                             onUpdateState({
                               editedWaitDate: date
-                                ? format(date, 'yyyy-MM-dd')
+                                ? hasTime
+                                  ? date.toISOString()
+                                  : format(date, 'yyyy-MM-dd')
                                 : '',
                             })
                           }
+                          placeholder="Select wait date and time"
                         />
 
                         <Button

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -1101,7 +1101,7 @@ describe('Tasks Component', () => {
   });
 
   test.each([
-    ['Wait', 'Wait:', 'Pick a date'],
+    ['Wait', 'Wait:', 'Select wait date and time'],
     ['End', 'End:', 'Select end date and time'],
     ['Due', 'Due:', 'Select due date and time'],
     ['Start', 'Start:', 'Select start date and time'],


### PR DESCRIPTION
### Description
Added  DateTimePicker support to the wait field in TaskDialog, allowing users to select both date and time for task wait dates.

- Contributes: #326

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

<img width="620" height="400" alt="Screenshot from 2026-01-01 12-31-43" src="https://github.com/user-attachments/assets/b9957311-10e7-4cc7-8810-2e66cc4a4344" />
<img width="620" height="400" alt="image" src="https://github.com/user-attachments/assets/722c3485-c71a-4110-a41a-b4737eb2f85f" />

