### PR TITLE
Fix: Overdue Tasks in Report

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/ReportsView.tsx
@@ -25,7 +25,19 @@ export const ReportsView: React.FC<ReportsViewProps> = ({ tasks }) => {
         if (!parsedDate) return false;
 
         const modifiedDate = getStartOfDay(parsedDate);
-        return modifiedDate >= filterDate;
+
+        // Include tasks within the time range
+        if (modifiedDate >= filterDate) {
+          return true;
+        }
+
+        // Also include overdue pending tasks even if their due date is before the filter date
+        // This ensures overdue tasks appear in current reports
+        if (task.status === 'pending' && task.due && isOverdue(task.due)) {
+          return true;
+        }
+
+        return false;
       })
       .reduce(
         (acc, task) => {

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportView.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/__snapshots__/ReportView.test.tsx.snap
@@ -606,7 +606,7 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
               ongoing: 1 
             </span>
             <span>
-              overdue: 0 
+              overdue: 3 
             </span>
           </div>
           <div
@@ -766,7 +766,7 @@ exports[`ReportsView Component using Snapshot renders correctly with only severa
               ongoing: 1 
             </span>
             <span>
-              overdue: 1 
+              overdue: 3 
             </span>
           </div>
           <div


### PR DESCRIPTION
### Description
The original filter logic only included tasks where `modifiedDate >= filterDate`. This meant that overdue tasks with past due dates were being filtered out before they could be counted as overdue, since their due dates were before the filter date (e.g., before "today" or "start of week").

- Fixes: #363 

### The Fix 
1. Include tasks within the time range (original behavior)
2. Also include overdue pending tasks even if their due date is before the filter date, since overdue tasks should always appear in current reports

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
<img width="529" height="396" alt="image" src="https://github.com/user-attachments/assets/ea4e41c4-2572-4b99-8e4c-e6199ed531cb" />

