### PR TITLE
feat(AddTaskDialog): add DateTimePicker for start field

### DIFF
--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -40,7 +40,11 @@ func AddTaskToTaskwarrior(req models.AddTaskRequestBody, dueDate string) error {
 		cmdArgs = append(cmdArgs, "due:"+dueDate)
 	}
 	if req.Start != "" {
-		cmdArgs = append(cmdArgs, "start:"+req.Start)
+		start, err := utils.ConvertISOToTaskwarriorFormat(req.Start)
+		if err != nil {
+			return fmt.Errorf("unexpected date format error: %v", err)
+		}
+		cmdArgs = append(cmdArgs, "start:"+start)
 	}
 	if len(req.Depends) > 0 {
 		dependsStr := strings.Join(req.Depends, ",")

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -288,15 +288,27 @@ export const AddTaskdialog = ({
               Start
             </Label>
             <div className="col-span-3">
-              <DatePicker
-                date={newTask.start ? new Date(newTask.start) : undefined}
-                onDateChange={(date) => {
+              <DateTimePicker
+                date={
+                  newTask.start
+                    ? new Date(
+                        newTask.start.includes('T')
+                          ? newTask.start
+                          : `${newTask.start}T00:00:00`
+                      )
+                    : undefined
+                }
+                onDateTimeChange={(date, hasTime) => {
                   setNewTask({
                     ...newTask,
-                    start: date ? format(date, 'yyyy-MM-dd') : '',
+                    start: date
+                      ? hasTime
+                        ? date.toISOString()
+                        : format(date, 'yyyy-MM-dd')
+                      : '',
                   });
                 }}
-                placeholder="Select a start date"
+                placeholder="Select start date and time"
               />
             </div>
           </div>


### PR DESCRIPTION
### Description

- Replace DatePicker with DateTimePicker for start field in AddTaskDialog
- Add DateTimePicker mock in AddTaskDialog.test.tsx
- Add comprehensive tests for DateTime fields (render, update, clear, submit)
- Support both date-only and datetime formats

- Contributes: #325 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Screenshots

<img width="553" height="710" alt="Screenshot 2026-01-06 at 4 06 55 PM" src="https://github.com/user-attachments/assets/0241d860-2cbd-4126-bdd8-b3729139b6cc" />
<img width="551" height="604" alt="Screenshot 2026-01-06 at 4 07 03 PM" src="https://github.com/user-attachments/assets/726da6ff-aee0-49a1-909d-65b39a10f045" />