### PR TITLE
fix: convert __NONE__ project placeholder to empty string

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -201,6 +201,9 @@ export const AddTaskdialog = ({
                   if (value === '__CREATE_NEW__') {
                     setIsCreatingNewProject(true);
                     setNewTask({ ...newTask, project: '' });
+                  } else if (value === '__NONE__') {
+                    setIsCreatingNewProject(false);
+                    setNewTask({ ...newTask, project: '' });
                   } else {
                     setIsCreatingNewProject(false);
                     setNewTask({ ...newTask, project: value });

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -202,6 +202,21 @@ describe('AddTaskDialog Component', () => {
   });
 
   describe('Project Field', () => {
+    test('sets project to empty string when "No project" is selected', () => {
+      mockProps.isOpen = true;
+      mockProps.uniqueProjects = ['Work', 'Personal'];
+      render(<AddTaskdialog {...mockProps} />);
+
+      const projectSelect = screen.getByTestId('project-select');
+      fireEvent.change(projectSelect, { target: { value: '__NONE__' } });
+
+      expect(mockProps.setIsCreatingNewProject).toHaveBeenCalledWith(false);
+      expect(mockProps.setNewTask).toHaveBeenCalledWith({
+        ...mockProps.newTask,
+        project: '',
+      });
+    });
+
     test('updates project when user types in project field', async () => {
       mockProps.isOpen = true;
       mockProps.isCreatingNewProject = true;


### PR DESCRIPTION
### Description

- Fixes bug where selecting "No project" stored "__NONE__" instead of empty string. Added unit test for this edge case.

- Fixes: #377 

### Additional Bug Found
While testing this fix, I discovered a related crash bug:

Steps to reproduce (before fix):

1. Open "Add Task" dialog
2. Click "No project"
3. Click "Create new project"
4. App crashes with black screen and removeChild DOM error

#### Video:

**Before:**

https://github.com/user-attachments/assets/51897198-af77-4b89-9037-5eb34906abf4

**After:**

https://github.com/user-attachments/assets/8f9d65e4-9183-44ea-819d-165459badc39


- This fix resolves both issues

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

