### PR TITLE
docs: fixed support link

### DIFF
--- a/frontend/src/components/HomeComponents/FAQ/FAQ.tsx
+++ b/frontend/src/components/HomeComponents/FAQ/FAQ.tsx
@@ -3,6 +3,7 @@ import { FAQItem } from './FAQItem';
 import { FAQList } from './faq-utils';
 import { BlueHeading } from '@/lib/utils';
 import { HighlightLink } from '@/components/ui/link-highlight';
+import { url } from '@/components/utils/URLs';
 
 export const FAQ = () => {
   return (
@@ -25,7 +26,7 @@ export const FAQ = () => {
 
       <h3 className="font-medium mt-4">
         Still have questions?{' '}
-        <HighlightLink rel="noreferrer noopener" href={'#contact'}>
+        <HighlightLink rel="noreferrer noopener" href={url.zulipURL}>
           Contact us
         </HighlightLink>
       </h3>

--- a/frontend/src/components/HomeComponents/FAQ/__tests__/FAQ.test.tsx
+++ b/frontend/src/components/HomeComponents/FAQ/__tests__/FAQ.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FAQ } from '../FAQ';
 import { FAQList } from '../faq-utils';
+import { url } from '@/components/utils/URLs';
 
 jest.mock('../faq-utils', () => ({
   FAQList: [
@@ -57,7 +58,7 @@ describe('FAQ component', () => {
     render(<FAQ />);
     const contactLink = screen.getByText(/Contact us/i);
     expect(contactLink).toBeInTheDocument();
-    expect(contactLink).toHaveAttribute('href', '#contact');
+    expect(contactLink).toHaveAttribute('href', url.zulipURL);
   });
 });
 

--- a/frontend/src/components/HomeComponents/FAQ/__tests__/__snapshots__/FAQ.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/FAQ/__tests__/__snapshots__/FAQ.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`FAQ component using snapshot renders correctly 1`] = `
       Still have questions? 
       <a
         class="opacity-60 hover:opacity-100 relative inline-block"
-        href="#contact"
+        href="https://ccextractor.org/public/general/support/"
         rel="noreferrer noopener"
       >
         Contact us


### PR DESCRIPTION
### Description

Fixed the support link to direct to ccextractor's support page.

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [ ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ ] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

<!-- Any additional info, screenshots, or context -->
