### PR TITLE
fix: upgrading deprecated terminology

### DIFF
--- a/backend/utils/tw/set_config.go
+++ b/backend/utils/tw/set_config.go
@@ -9,7 +9,7 @@ import (
 func SetTaskwarriorConfig(tempDir, encryptionSecret, origin, UUID string) error {
 	configCmds := [][]string{
 		{"task", "config", "sync.encryption_secret", encryptionSecret, "rc.confirmation=off"},
-		{"task", "config", "sync.server.origin", origin, "rc.confirmation=off"},
+		{"task", "config", "sync.server.url", origin, "rc.confirmation=off"},
 		{"task", "config", "sync.server.client_id", UUID, "rc.confirmation=off"},
 	}
 

--- a/frontend/src/components/HomeComponents/SetupGuide/SetupGuide.tsx
+++ b/frontend/src/components/HomeComponents/SetupGuide/SetupGuide.tsx
@@ -74,9 +74,13 @@ export const SetupGuide = (props: Props) => {
                     commands one block at a time
                   </div>
                   <CopyableCode
-                    text={`task config sync.server.origin ${url.containerOrigin}`}
-                    copyText={`task config sync.server.origin ${url.containerOrigin}`}
+                    text={`task config sync.server.url ${url.containerOrigin}`}
+                    copyText={`task config sync.server.url ${url.containerOrigin}`}
                   />
+                  <div className="text-sm text-muted-foreground mt-2 mb-2">
+                    (Note: <code>sync.server.origin</code> is deprecated but
+                    synonymous with <code>sync.server.url</code>)
+                  </div>
                   <CopyableCode
                     text={`task config sync.server.client_id ${props.uuid}`}
                     copyText={`task config sync.server.client_id ${props.uuid}`}

--- a/frontend/src/components/HomeComponents/SetupGuide/__tests__/SetupGuide.test.tsx
+++ b/frontend/src/components/HomeComponents/SetupGuide/__tests__/SetupGuide.test.tsx
@@ -54,7 +54,7 @@ describe('SetupGuide', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('task config sync.server.origin https://test-container')
+      screen.getByText('task config sync.server.url https://test-container')
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/HomeComponents/SetupGuide/__tests__/utils.test.ts
+++ b/frontend/src/components/HomeComponents/SetupGuide/__tests__/utils.test.ts
@@ -19,7 +19,7 @@ describe('exportConfigSetup', () => {
     );
 
     expect(result).toContain(
-      `task config sync.server.origin ${url.containerOrigin}`
+      `task config sync.server.url ${url.containerOrigin}`
     );
 
     expect(result).toContain(`task config sync.server.client_id ${props.uuid}`);

--- a/frontend/src/components/HomeComponents/SetupGuide/utils.ts
+++ b/frontend/src/components/HomeComponents/SetupGuide/utils.ts
@@ -5,7 +5,8 @@ export function exportConfigSetup(props: Props): string {
   return [
     'Configure Taskwarrior with these commands, run these commands one block at a time',
     `task config sync.encryption_secret ${props.encryption_secret}`,
-    `task config sync.server.origin ${url.containerOrigin}`,
+    `task config sync.server.url ${url.containerOrigin}`,
+    '(Note: sync.server.origin is deprecated but synonymous with sync.server.url)',
     `task config sync.server.client_id ${props.uuid}`,
     'For more information about how this works, refer to the task-sync(5) manpage for details on how to configure the new sync implementation.',
   ].join('\n');


### PR DESCRIPTION
### Description

Upgrading deprecated terminology of taskserver's environment value

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [x] Updated documentation, if needed

