### PR TITLE
feat(AddTaskDialog): add DateTimePicker for wait field

### DIFF
--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -54,7 +54,11 @@ func AddTaskToTaskwarrior(req models.AddTaskRequestBody, dueDate string) error {
 		cmdArgs = append(cmdArgs, "entry:"+req.EntryDate)
 	}
 	if req.WaitDate != "" {
-		cmdArgs = append(cmdArgs, "wait:"+req.WaitDate)
+		wait, err := utils.ConvertISOToTaskwarriorFormat(req.WaitDate)
+		if err != nil {
+			return fmt.Errorf("unexpected date format error: %v", err)
+		}
+		cmdArgs = append(cmdArgs, "wait:"+wait)
 	}
 	if req.End != "" {
 		cmdArgs = append(cmdArgs, "end:"+req.End)

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -351,15 +351,27 @@ export const AddTaskdialog = ({
               Wait
             </Label>
             <div className="col-span-3">
-              <DatePicker
-                date={newTask.wait ? new Date(newTask.wait) : undefined}
-                onDateChange={(date) => {
+              <DateTimePicker
+                date={
+                  newTask.wait
+                    ? new Date(
+                        newTask.wait.includes('T')
+                          ? newTask.wait
+                          : `${newTask.wait}T00:00:00`
+                      )
+                    : undefined
+                }
+                onDateTimeChange={(date, hasTime) => {
                   setNewTask({
                     ...newTask,
-                    wait: date ? format(date, 'yyyy-MM-dd') : '',
+                    wait: date
+                      ? hasTime
+                        ? date.toISOString()
+                        : format(date, 'yyyy-MM-dd')
+                      : '',
                   });
                 }}
-                placeholder="Select a wait date"
+                placeholder="Select wait date and time"
               />
             </div>
           </div>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -401,6 +401,11 @@ describe('AddTaskDialog Component', () => {
           label: 'Start',
           placeholder: 'Select start date and time',
         },
+        {
+          name: 'wait',
+          label: 'Wait',
+          placeholder: 'Select wait date and time',
+        },
       ];
 
       test.each(dateTimeFields)(
@@ -507,7 +512,6 @@ describe('AddTaskDialog Component', () => {
       const dateOnlyFields = [
         { name: 'end', label: 'End', placeholder: 'Select an end date' },
         { name: 'entry', label: 'Entry', placeholder: 'Select an entry date' },
-        { name: 'wait', label: 'Wait', placeholder: 'Select a wait date' },
       ];
 
       test.each(dateOnlyFields)(


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes made in this PR -->

- Replace DatePicker with DateTimePicker for wait field in AddTaskDialog
- Add wait to dateTimeFields array in tests
- Support both date-only and datetime formats for wait

- Contributes: #325 

#### **Stacked PR** -> please merge after PR #376 
### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Screenshots:

<!-- Any additional info, screenshots, or context -->
<img width="354" height="505" alt="Screenshot 2026-01-08 at 9 44 19 PM" src="https://github.com/user-attachments/assets/91a93590-af82-489e-b488-bc0d22707a0e" />

<img width="353" height="652" alt="Screenshot 2026-01-08 at 9 44 55 PM" src="https://github.com/user-attachments/assets/92b83770-3ff6-4905-a4f4-f2d966c5dad6" />
