### PR TITLE
feat(AddTaskDialog): add DateTimePicker for entry field

### DIFF
--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -51,7 +51,11 @@ func AddTaskToTaskwarrior(req models.AddTaskRequestBody, dueDate string) error {
 		cmdArgs = append(cmdArgs, "depends:"+dependsStr)
 	}
 	if req.EntryDate != "" {
-		cmdArgs = append(cmdArgs, "entry:"+req.EntryDate)
+		entry, err := utils.ConvertISOToTaskwarriorFormat(req.EntryDate)
+		if err != nil {
+			return fmt.Errorf("unexpected date format error: %v", err)
+		}
+		cmdArgs = append(cmdArgs, "entry:"+entry)
 	}
 	if req.WaitDate != "" {
 		wait, err := utils.ConvertISOToTaskwarriorFormat(req.WaitDate)

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -334,15 +334,27 @@ export const AddTaskdialog = ({
               Entry
             </Label>
             <div className="col-span-3">
-              <DatePicker
-                date={newTask.entry ? new Date(newTask.entry) : undefined}
-                onDateChange={(date) => {
+              <DateTimePicker
+                date={
+                  newTask.entry
+                    ? new Date(
+                        newTask.entry.includes('T')
+                          ? newTask.entry
+                          : `${newTask.entry}T00:00:00`
+                      )
+                    : undefined
+                }
+                onDateTimeChange={(date, hasTime) => {
                   setNewTask({
                     ...newTask,
-                    entry: date ? format(date, 'yyyy-MM-dd') : '',
+                    entry: date
+                      ? hasTime
+                        ? date.toISOString()
+                        : format(date, 'yyyy-MM-dd')
+                      : '',
                   });
                 }}
-                placeholder="Select an entry date"
+                placeholder="Select entry date and time"
               />
             </div>
           </div>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -406,6 +406,11 @@ describe('AddTaskDialog Component', () => {
           label: 'Wait',
           placeholder: 'Select wait date and time',
         },
+        {
+          name: 'entry',
+          label: 'Entry',
+          placeholder: 'Select entry date and time',
+        },
       ];
 
       test.each(dateTimeFields)(
@@ -511,7 +516,6 @@ describe('AddTaskDialog Component', () => {
     describe('DatePicker fields', () => {
       const dateOnlyFields = [
         { name: 'end', label: 'End', placeholder: 'Select an end date' },
-        { name: 'entry', label: 'Entry', placeholder: 'Select an entry date' },
       ];
 
       test.each(dateOnlyFields)(


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes made in this PR -->

- Replace DatePicker with DateTimePicker for entry field in AddTaskDialog
- Add entry to dateTimeFields array in tests
- Support both date-only and datetime formats for entry

- Contributes: #325 

#### **Stacked PR** -> please merge after PR #376 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

<!-- Any additional info, screenshots, or context -->

#### Screenshots:

<img width="355" height="498" alt="Screenshot 2026-01-08 at 9 49 53 PM" src="https://github.com/user-attachments/assets/085d0b37-99ce-4037-b5ef-5972b0772aa8" />
<img width="344" height="653" alt="Screenshot 2026-01-08 at 9 50 04 PM" src="https://github.com/user-attachments/assets/686824c3-b2fe-4e26-ae81-8420abb6d900" />
