### PR TITLE
Modified CI To  run backend tests on pull requests

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+      - dev
+      
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR updates the backend CI workflow to ensure backend tests run on pull requests, not only after code is merged into `main`.

### Problem
Currently, backend tests are triggered only on pushes to the `main` branch. As a result, pull requests can be merged without backend test coverage.

### Changes
- Added a `pull_request` trigger to `.github/workflows/backend-test.yml`
- Backend tests now run for pull requests targeting `main` and `dev`


- Fixes: #388 

### Checklist

- [ ] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [ ] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [ ] Verified all tests pass
- [ ] Updated documentation, if needed

