### PR TITLE
feat(AddTaskDialog): add end date datetime picker

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { DatePicker } from '@/components/ui/date-picker';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 import {
   Dialog,
@@ -401,17 +400,36 @@ export const AddTaskdialog = ({
                 End
               </Label>
               <div className="col-span-3">
-                <DatePicker
+                <DateTimePicker
                   ref={(element) => (inputRefs.current.end = element)}
-                  date={newTask.end ? new Date(newTask.end) : undefined}
-                  onDateChange={(date) => {
+                  date={
+                    newTask.end
+                      ? new Date(
+                          newTask.end.includes('T')
+                            ? newTask.end
+                            : `${newTask.end}T00:00:00`
+                        )
+                      : undefined
+                  }
+                  onDateTimeChange={(date, hasTime) => {
                     setNewTask({
                       ...newTask,
-                      end: date ? format(date, 'yyyy-MM-dd') : '',
+                      end: date
+                        ? hasTime
+                          ? date.toISOString()
+                          : format(date, 'yyyy-MM-dd')
+                        : '',
                     });
                   }}
-                  placeholder="Select an end date"
+                  placeholder="Select end date and time"
                 />
+                {newTask.end && (
+                  <div className="mt-1.5 pl-2.5 border-l-2 border-amber-500/60">
+                    <p className="text-xs text-amber-400 leading-tight">
+                      Task will be marked as completed
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
             <div

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/AddTaskDialog.test.tsx
@@ -12,22 +12,6 @@ jest.mock('date-fns', () => ({
   }),
 }));
 
-jest.mock('@/components/ui/date-picker', () => ({
-  DatePicker: ({ onDateChange, placeholder }: any) => (
-    <input
-      data-testid="date-picker"
-      placeholder={placeholder}
-      onChange={(e) => {
-        if (e.target.value) {
-          onDateChange(new Date(e.target.value));
-        } else {
-          onDateChange(null);
-        }
-      }}
-    />
-  ),
-}));
-
 jest.mock('@/components/ui/date-time-picker', () => ({
   DateTimePicker: ({ onDateTimeChange, placeholder }: any) => (
     <div>
@@ -431,6 +415,11 @@ describe('AddTaskDialog Component', () => {
           label: 'Entry',
           placeholder: 'Select entry date and time',
         },
+        {
+          name: 'end',
+          label: 'End',
+          placeholder: 'Select end date and time',
+        },
       ];
 
       test.each(dateTimeFields)(
@@ -533,75 +522,27 @@ describe('AddTaskDialog Component', () => {
       );
     });
 
-    describe('DatePicker fields', () => {
-      const dateOnlyFields = [
-        { name: 'end', label: 'End', placeholder: 'Select an end date' },
-      ];
+    describe('End date warning message', () => {
+      test('should show warning when end date is selected', () => {
+        mockProps.isOpen = true;
+        mockProps.newTask.end = '2026-01-18';
 
-      test.each(dateOnlyFields)(
-        'renders $name date picker with correct placeholder',
-        ({ placeholder }) => {
-          mockProps.isOpen = true;
-          render(<AddTaskdialog {...mockProps} />);
+        render(<AddTaskdialog {...mockProps} />);
 
-          const datePicker = screen.getByPlaceholderText(placeholder);
-          expect(datePicker).toBeInTheDocument();
-        }
-      );
+        expect(
+          screen.getByText(/task will be marked as completed/i)
+        ).toBeInTheDocument();
+      });
 
-      test.each(dateOnlyFields)(
-        'updates $name when user selects a date',
-        ({ name, placeholder }) => {
-          mockProps.isOpen = true;
-          render(<AddTaskdialog {...mockProps} />);
+      test('should not show warning when end date is empty', () => {
+        mockProps.isOpen = true;
 
-          const datePicker = screen.getByPlaceholderText(placeholder);
-          fireEvent.change(datePicker, { target: { value: '2025-12-25' } });
+        render(<AddTaskdialog {...mockProps} />);
 
-          expect(mockProps.setNewTask).toHaveBeenCalledWith({
-            ...mockProps.newTask,
-            [name]: '2025-12-25',
-          });
-        }
-      );
-
-      test.each(dateOnlyFields)(
-        'allows empty $name date (optional field)',
-        ({ name, placeholder }) => {
-          mockProps.isOpen = true;
-          render(<AddTaskdialog {...mockProps} />);
-
-          const datePicker = screen.getByPlaceholderText(placeholder);
-
-          fireEvent.change(datePicker, { target: { value: '2025-12-25' } });
-          mockProps.setNewTask.mockClear();
-          fireEvent.change(datePicker, { target: { value: '' } });
-
-          expect(mockProps.setNewTask).toHaveBeenCalledWith({
-            ...mockProps.newTask,
-            [name]: '',
-          });
-        }
-      );
-
-      test.each(dateOnlyFields)(
-        'submits task with $name date when provided',
-        ({ name }) => {
-          mockProps.isOpen = true;
-          mockProps.newTask = {
-            ...mockProps.newTask,
-            [name]: '2025-12-25',
-          };
-          render(<AddTaskdialog {...mockProps} />);
-
-          const submitButton = screen.getByRole('button', {
-            name: /add task/i,
-          });
-          fireEvent.click(submitButton);
-
-          expect(mockProps.onSubmit).toHaveBeenCalledWith(mockProps.newTask);
-        }
-      );
+        expect(
+          screen.queryByText(/task will be marked as completed/i)
+        ).not.toBeInTheDocument();
+      });
     });
   });
 


### PR DESCRIPTION
### Description

- Replace DatePicker with DateTimePicker for end field in AddTaskDialog
- Add end to dateTimeFields array in tests
- Support both date-only and datetime formats for end
- Mark task as completed when end date is set via `task done` command in backend
- Show inline warning message when end date is selected
- Add warning message visibility tests

- Fixes: #325 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

**Why `task done` is used:** Taskwarrior does not allow setting an end date on a pending task. The only way is via `task done end:<date>`, which marks the task as completed. Future end dates are allowed (as discussed with maintainer), the inline warning informs users of completion behavior.

#### Screenshots:
<img width="329" height="269" alt="Screenshot 2026-01-18 at 8 34 47 PM" src="https://github.com/user-attachments/assets/8b337eb3-7059-4e41-a6a9-af3eef2da082" />
<img width="378" height="330" alt="Screenshot 2026-01-18 at 8 43 47 PM" src="https://github.com/user-attachments/assets/3da2803e-cfa8-48b8-a8ea-3f61b0839b67" />



#### Video:


https://github.com/user-attachments/assets/d7fe862b-f727-4d4e-a3ad-61d3571b73c1

