### PR TITLE
fix: prevent Task Dialog blink when pinning/unpinning tasks

### DIFF
--- a/frontend/src/components/HomeComponents/Tasks/UseEditTask.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/UseEditTask.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { EditTaskState, Task } from '../../utils/types';
 
 export const useEditTask = (selectedTask: Task | null) => {
@@ -34,23 +34,29 @@ export const useEditTask = (selectedTask: Task | null) => {
     annotationInput: '',
   });
 
+  const previousTaskUuidRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (selectedTask) {
-      setState((prev) => ({
-        ...prev,
-        editedTags: selectedTask.tags || [],
-        editedDescription: selectedTask.description || '',
-        editedPriority: selectedTask.priority || 'NONE',
-        editedProject: selectedTask.project || '',
-        editedRecur: selectedTask.recur || '',
-        originalRecur: selectedTask.recur || '',
-        editedAnnotations: selectedTask.annotations || [],
-        editedDepends: selectedTask.depends || [],
-      }));
+      if (previousTaskUuidRef.current !== selectedTask.uuid) {
+        previousTaskUuidRef.current = selectedTask.uuid;
+        setState((prev) => ({
+          ...prev,
+          editedTags: selectedTask.tags || [],
+          editedDescription: selectedTask.description || '',
+          editedPriority: selectedTask.priority || 'NONE',
+          editedProject: selectedTask.project || '',
+          editedRecur: selectedTask.recur || '',
+          originalRecur: selectedTask.recur || '',
+          editedAnnotations: selectedTask.annotations || [],
+          editedDepends: selectedTask.depends || [],
+        }));
+      }
     }
   }, [selectedTask]);
 
   const resetState = () => {
+    previousTaskUuidRef.current = null;
     setState({
       isEditing: false,
       editedDescription: '',


### PR DESCRIPTION
### Description
- Fixes: #399 
- Changed useEditTask hook to use UUID comparison instead of object reference
- Prevents unnecessary edit state resets on component re-renders
- Dialog now stays stable when toggling pin status

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
Single file change in `UseEditTask.tsx` - added ref to track task UUID for proper change detection.

### Snapshot
[Screencast from 2026-01-19 01-04-38.webm](https://github.com/user-attachments/assets/ec34af25-0e18-46cb-97d1-38e1346b50d9)
