### PR TITLE
fix: healthchecks and add standard port sync server access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # env_file:
     # - ./frontend/.env
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:80"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -30,7 +30,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -44,7 +44,8 @@ services:
     networks:
       - tasknetwork
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      # Note: taskchampion-sync-server doesn't have a /health endpoint, use root
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/production/example.frontend.env
+++ b/production/example.frontend.env
@@ -1,3 +1,5 @@
 VITE_BACKEND_URL="https://your-domain.com/"
 VITE_FRONTEND_URL="https://your-domain.com"
-VITE_CONTAINER_ORIGIN="https://your-domain.com:8080/"
+# Use standard port 443 with /taskchampion/ path (recommended)
+VITE_CONTAINER_ORIGIN="https://your-domain.com/taskchampion/"
+# Or use legacy port 8080: VITE_CONTAINER_ORIGIN="https://your-domain.com:8080/"

--- a/production/example.nginx.conf
+++ b/production/example.nginx.conf
@@ -171,6 +171,17 @@ server {
         proxy_read_timeout 86400;
     }
 
+    # Taskchampion sync server on standard port 443
+    # Users can configure: task config sync.server.url https://your-domain.com/taskchampion/
+    location /taskchampion/ {
+        proxy_pass http://127.0.0.1:8081/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Frontend (default)
     location / {
         proxy_pass http://127.0.0.1:3000;
@@ -182,7 +193,7 @@ server {
     }
 }
 
-# Taskchampion sync server (port 8080 with SSL)
+# Taskchampion sync server (port 8080 with SSL) - Legacy support
 server {
     listen 8080 ssl http2;
     listen [::]:8080 ssl http2;


### PR DESCRIPTION
## Summary
- Fix Docker healthchecks to use `wget` instead of `curl` (curl is not available in Alpine-based containers)
- Use `127.0.0.1` instead of `localhost` in healthchecks (localhost doesn't resolve correctly in some Alpine containers)
- Fix syncserver healthcheck to check `/` instead of `/health` (taskchampion-sync-server doesn't have a /health endpoint)
- Add `/taskchampion/` path in nginx config for sync server access on standard port 443
- Update `example.frontend.env` to use the new `/taskchampion/` path as default

## Changes
1. **docker-compose.yml**: Fixed all three healthchecks
2. **production/example.nginx.conf**: Added `/taskchampion/` location block, marked port 8080 as legacy
3. **production/example.frontend.env**: Updated to use `/taskchampion/` path with legacy option documented

## Benefits
- Healthchecks now work correctly (containers show "healthy" instead of "unhealthy")
- Users can access sync server on standard HTTPS port 443 via `/taskchampion/` path
- No need to open additional firewall port (8080) in production
- Legacy port 8080 still supported for backward compatibility

## Test plan
- [ ] Run `docker compose up -d` and verify all containers show healthy status
- [ ] Verify sync server accessible at `/taskchampion/` path
- [ ] Verify legacy port 8080 still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)