### PR TITLE
security: add authentication middleware to validate API credentials

### DIFF
--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"bytes"
+	"ccsync_backend/utils"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+)
+
+// credentialsPayload represents the common credential fields in request bodies
+type credentialsPayload struct {
+	Email            string `json:"email"`
+	EncryptionSecret string `json:"encryptionSecret"`
+	UUID             string `json:"UUID"`
+}
+
+// AuthMiddleware validates that the user is authenticated and that request body
+// credentials match the session credentials to prevent unauthorized access.
+func AuthMiddleware(store *sessions.CookieStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get session
+			session, err := store.Get(r, "session-name")
+			if err != nil {
+				utils.Logger.Warnf("Auth middleware: failed to get session: %v", err)
+				http.Error(w, "Authentication required", http.StatusUnauthorized)
+				return
+			}
+
+			// Check if user is authenticated
+			userInfo, ok := session.Values["user"].(map[string]interface{})
+			if !ok || userInfo == nil {
+				http.Error(w, "Authentication required", http.StatusUnauthorized)
+				return
+			}
+
+			// Extract session credentials
+			sessionEmail, _ := userInfo["email"].(string)
+			sessionUUID, _ := userInfo["uuid"].(string)
+			sessionSecret, _ := userInfo["encryption_secret"].(string)
+
+			if sessionEmail == "" || sessionUUID == "" || sessionSecret == "" {
+				utils.Logger.Warnf("Auth middleware: incomplete session credentials")
+				http.Error(w, "Authentication required", http.StatusUnauthorized)
+				return
+			}
+
+			// For POST requests with JSON body, validate credentials match session
+			if r.Method == http.MethodPost && r.Body != nil {
+				// Read the body
+				bodyBytes, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "Failed to read request body", http.StatusBadRequest)
+					return
+				}
+				// Restore the body for the next handler
+				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+				// Parse credentials from body
+				var creds credentialsPayload
+				if err := json.Unmarshal(bodyBytes, &creds); err == nil {
+					// If credentials are provided in the body, validate they match session
+					if creds.Email != "" || creds.UUID != "" || creds.EncryptionSecret != "" {
+						if creds.Email != sessionEmail {
+							utils.Logger.Warnf("Auth middleware: email mismatch - session=%s, request=%s", sessionEmail, creds.Email)
+							http.Error(w, "Credential mismatch: email does not match session", http.StatusForbidden)
+							return
+						}
+						if creds.UUID != sessionUUID {
+							utils.Logger.Warnf("Auth middleware: UUID mismatch - session=%s, request=%s", sessionUUID, creds.UUID)
+							http.Error(w, "Credential mismatch: UUID does not match session", http.StatusForbidden)
+							return
+						}
+						if creds.EncryptionSecret != sessionSecret {
+							utils.Logger.Warnf("Auth middleware: encryption secret mismatch for user %s", sessionEmail)
+							http.Error(w, "Credential mismatch: encryption secret does not match session", http.StatusForbidden)
+							return
+						}
+					}
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add authentication middleware that validates user sessions
- Validate that request body credentials match session credentials
- Prevents users from manipulating credentials to access other users' tasks

## Security Issue Addressed
**Missing Authorization on API Endpoints (High)** - Previously, task endpoints accepted credentials from the request body without validating them against the authenticated session. An attacker could potentially supply different credentials to access or modify other users' tasks.

## Changes
- `backend/middleware/auth.go`: New authentication middleware that:
  - Validates user has an authenticated session
  - For POST requests, validates credentials in body match session
  - Returns 401 Unauthorized if no session
  - Returns 403 Forbidden if credentials mismatch
  - Logs warnings for mismatch attempts

- `backend/main.go`: Apply auth middleware to task endpoints
  - Auth-only: `/auth/*`, `/api/user`, `/sync/logs`
  - Auth + validation: `/tasks`, `/add-task`, `/edit-task`, `/modify-task`, `/complete-task`, `/delete-task`, `/complete-tasks`, `/delete-tasks`

## Test plan
- [ ] Test task operations work correctly with valid session
- [ ] Verify unauthenticated requests are rejected (401)
- [ ] Verify mismatched credentials are rejected (403)
- [ ] Verify auth endpoints still work without auth middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)