### PR TITLE
security: sanitize user input in temp directory names

### DIFF
--- a/backend/utils/sanitize.go
+++ b/backend/utils/sanitize.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SafeTempDirPrefix creates a safe prefix for temporary directory names.
+// Instead of using user-provided values directly (which could contain path
+// separators or special characters), we use a hash of the value.
+// This prevents directory traversal attacks while still providing
+// unique prefixes per user.
+func SafeTempDirPrefix(prefix, userIdentifier string) string {
+	// Create a short hash of the user identifier
+	hash := sha256.Sum256([]byte(userIdentifier))
+	// Use first 8 characters of hex-encoded hash (32 bits of entropy)
+	shortHash := hex.EncodeToString(hash[:])[:8]
+	return prefix + shortHash
+}

--- a/backend/utils/tw/add_task.go
+++ b/backend/utils/tw/add_task.go
@@ -14,7 +14,7 @@ func AddTaskToTaskwarrior(req models.AddTaskRequestBody, dueDate string) error {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
 
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+req.Email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", req.Email))
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/backend/utils/tw/complete_task.go
+++ b/backend/utils/tw/complete_task.go
@@ -10,7 +10,7 @@ func CompleteTaskInTaskwarrior(email, encryptionSecret, uuid, taskuuid string) e
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/backend/utils/tw/complete_tasks.go
+++ b/backend/utils/tw/complete_tasks.go
@@ -13,7 +13,7 @@ func CompleteTasksInTaskwarrior(email, encryptionSecret, uuid string, taskUUIDs 
 		return nil, fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
 
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %v", err)

--- a/backend/utils/tw/delete_task.go
+++ b/backend/utils/tw/delete_task.go
@@ -10,7 +10,7 @@ func DeleteTaskInTaskwarrior(email, encryptionSecret, uuid, taskuuid string) err
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/backend/utils/tw/delete_tasks.go
+++ b/backend/utils/tw/delete_tasks.go
@@ -13,7 +13,7 @@ func DeleteTasksInTaskwarrior(email, encryptionSecret, uuid string, taskUUIDs []
 		return nil, fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
 
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %v", err)

--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -13,7 +13,7 @@ func EditTaskInTaskwarrior(uuid, description, email, encryptionSecret, taskID st
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/backend/utils/tw/fetch_tasks.go
+++ b/backend/utils/tw/fetch_tasks.go
@@ -14,7 +14,7 @@ func FetchTasksFromTaskwarrior(email, encryptionSecret, origin, UUID string) ([]
 		return nil, fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
 
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/backend/utils/tw/modify_task.go
+++ b/backend/utils/tw/modify_task.go
@@ -11,7 +11,7 @@ func ModifyTaskInTaskwarrior(uuid, description, project, priority, status, due, 
 	if err := utils.ExecCommand("rm", "-rf", "/root/.task"); err != nil {
 		return fmt.Errorf("error deleting Taskwarrior data: %v", err)
 	}
-	tempDir, err := os.MkdirTemp("", "taskwarrior-"+email)
+	tempDir, err := os.MkdirTemp("", utils.SafeTempDirPrefix("taskwarrior-", email))
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Replace direct use of email in temp directory names with a SHA256 hash
- Prevent directory traversal attacks from malicious email values

## Security Issue Addressed
**Directory Traversal Risk (Medium)** - Previously, user email was used directly in temporary directory names via `os.MkdirTemp("", "taskwarrior-"+email)`. If the email contained path separators or special characters, it could potentially cause path-related issues.

## Changes
- `backend/utils/sanitize.go`: New file with `SafeTempDirPrefix()` function
  - Takes a prefix and user identifier
  - Returns prefix + 8-character SHA256 hash of the identifier
  - Provides unique prefixes per user without exposing user data

- Updated files to use `SafeTempDirPrefix`:
  - `backend/utils/tw/add_task.go`
  - `backend/utils/tw/complete_task.go`
  - `backend/utils/tw/complete_tasks.go`
  - `backend/utils/tw/delete_task.go`
  - `backend/utils/tw/delete_tasks.go`
  - `backend/utils/tw/edit_task.go`
  - `backend/utils/tw/fetch_tasks.go`
  - `backend/utils/tw/modify_task.go`

## Test plan
- [ ] Verify task operations work correctly
- [ ] Verify temp directories are created with hashed names
- [ ] Verify temp directories are cleaned up after operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)