### PR TITLE
security: sanitize error messages to prevent info disclosure

### DIFF
--- a/backend/controllers/add_task.go
+++ b/backend/controllers/add_task.go
@@ -27,7 +27,8 @@ func AddTaskHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		var requestBody models.AddTaskRequestBody
 		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-			http.Error(w, fmt.Sprintf("error decoding request body: %v", err), http.StatusBadRequest)
+			utils.Logger.Warnf("Failed to decode add task request: %v", err)
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
 			return
 		}
 		defer r.Body.Close()


### PR DESCRIPTION
## Summary
- Replace detailed error messages with generic ones to prevent information disclosure
- Log actual errors for debugging while showing safe messages to users

## Security Issue Addressed
**Debug Information Disclosure (Low)** - Previously, detailed error messages (including internal error details) were returned to users. This could leak sensitive information about the system, libraries used, or internal structure.

## Changes
- `backend/controllers/app_handlers.go`:
  - OAuth errors: Show "Authentication failed" instead of `err.Error()`
  - Session errors: Show "Session error" instead of `err.Error()`
  - Logout errors: Show "Logout failed" instead of `err.Error()`
  - Log actual errors for debugging

- `backend/controllers/add_task.go`:
  - JSON decode errors: Show "Invalid request body" instead of decode error details

## Notes
- Validation errors (like "Invalid date format", "Invalid dependencies") are intentionally kept as they help users understand what needs to be fixed
- This is a focused fix for the most critical error exposures; additional controllers could be updated similarly in follow-up PRs

## Test plan
- [ ] Verify OAuth errors show generic message
- [ ] Verify session errors show generic message
- [ ] Verify detailed errors are logged server-side
- [ ] Verify validation errors still provide helpful feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)