### PR TITLE
fix: auto-sync tasks after editing .

### DIFF
--- a/frontend/src/components/HomeComponents/Navbar/__tests__/NavbarDesktop.test.tsx
+++ b/frontend/src/components/HomeComponents/Navbar/__tests__/NavbarDesktop.test.tsx
@@ -154,7 +154,10 @@ describe('NavbarDesktop', () => {
     render(<NavbarDesktop {...props} />);
 
     await userEvent.click(screen.getByText('CN'));
-    await userEvent.click(screen.getByText('toggle'));
+
+    // Click the first toggle (Auto sync tasks)
+    const toggleButtons = screen.getAllByText('toggle');
+    await userEvent.click(toggleButtons[0]);
 
     expect(screen.getByTestId('sync-slider')).toBeInTheDocument();
   });

--- a/frontend/src/components/HomeComponents/Navbar/__tests__/__snapshots__/NavbarDesktop.test.tsx.snap
+++ b/frontend/src/components/HomeComponents/Navbar/__tests__/__snapshots__/NavbarDesktop.test.tsx.snap
@@ -375,6 +375,21 @@ exports[`NavbarDesktop renders consistently (snapshot) 1`] = `
             </div>
           </div>
           <div>
+            <div
+              class="flex items-center justify-between space-x-2 w-full p-1"
+            >
+              <label
+                class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                for="autosync-on-edit-switch"
+              >
+                Auto sync on edit
+              </label>
+              <button>
+                toggle
+              </button>
+            </div>
+          </div>
+          <div>
             <svg
               class="lucide lucide-log-out mr-2 h-4 w-4"
               fill="none"

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../tasks-utils', () => {
     getTimeSinceLastSync: jest
       .fn()
       .mockReturnValue('Last updated 5 minutes ago'),
-    hashKey: jest.fn().mockReturnValue('mockHashedKey'),
+    hashKey: jest.fn((key: string) => `mockHashedKey-${key}`),
     getPinnedTasks: jest.fn().mockReturnValue(new Set()),
     togglePinnedTask: jest.fn(),
   };
@@ -203,6 +203,8 @@ describe('Tasks Component', () => {
   beforeEach(() => {
     localStorageMock.clear();
     jest.clearAllMocks();
+    // Disable auto-sync on edit for tests (to avoid unexpected sync calls)
+    localStorageMock.setItem('mockHashedKey-autoSyncOnEdit', 'false');
   });
 
   describe('Rendering & Basic UI', () => {
@@ -255,7 +257,7 @@ describe('Tasks Component', () => {
 
   describe('LocalStorage', () => {
     test('loads "tasksPerPage" from localStorage on initial render', async () => {
-      localStorageMock.setItem('mockHashedKey', '20');
+      localStorageMock.setItem('mockHashedKey-tasksPerPage', '20');
 
       render(<Tasks {...mockProps} />);
 
@@ -277,7 +279,7 @@ describe('Tasks Component', () => {
       expect(screen.getByTestId('total-pages')).toHaveTextContent('4');
 
       expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        'mockHashedKey',
+        'mockHashedKey-tasksPerPage',
         '5'
       );
 


### PR DESCRIPTION
### Description
Added auto-sync after task editing to eliminate manual sync button click. Backend uses async job queue, so added 1-second delay before syncing to ensure job completes.

- Fixes: #415

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes
Only frontend change - 3 lines in `handleEditTaskOnBackend()` to wait for async job then auto-sync.



https://github.com/user-attachments/assets/459989f7-0f40-4f5e-a6eb-3898e5e62820





