### PR TITLE
fix: add ENV=production to Kubernetes deployment for secure session cookies

### DIFF
--- a/production/README.md
+++ b/production/README.md
@@ -5,6 +5,7 @@
 1. Create a file named `.backend.env` with the following attributes:
 
 ```bash
+ENV="production" # Required for secure HTTPS-only cookies
 CLIENT_ID="client_ID" # Google Auth Secret from Prerequisites
 CLIENT_SEC="client_SECRET" # Google Auth Secret from Prerequisites
 REDIRECT_URL_DEV="http://localhost:8000/auth/callback"
@@ -84,6 +85,7 @@ services:
 
 Create `.backend.env`:
 ```bash
+ENV="production"
 CLIENT_ID="your-google-client-id"
 CLIENT_SEC="your-google-client-secret"
 REDIRECT_URL_DEV="https://your-domain.com/auth/callback"

--- a/production/backend-deployment.yaml
+++ b/production/backend-deployment.yaml
@@ -40,6 +40,11 @@ spec:
                 configMapKeyRef:
                   key: CONTAINER_ORIGIN
                   name: backend-env
+            - name: ENV
+              valueFrom:
+                configMapKeyRef:
+                  key: ENV
+                  name: backend-env
             - name: FRONTEND_ORIGIN_DEV
               valueFrom:
                 configMapKeyRef:

--- a/production/backend-env-configmap.yaml
+++ b/production/backend-env-configmap.yaml
@@ -3,6 +3,7 @@ data:
   CLIENT_ID: "YOUR_GOOGLE_CLOUD_AUTH_CLIENT_ID" # Replace this in order to access the frontend
   CLIENT_SEC: "YOUR_GOOGLE_CLOUD_AUTH_CLIENT_SECRET" # Replace this in order to access the frontend
   CONTAINER_ORIGIN: http://syncserver:8080/
+  ENV: "production" # Required for secure HTTPS-only cookies
   FRONTEND_ORIGIN_DEV: http://localhost
   PORT: "8000"
   REDIRECT_URL_DEV: http://localhost:8000/auth/callback


### PR DESCRIPTION
### Description

Added ENV=production to Kubernetes deployment configuration to enable secure HTTPS-only session cookies, fixing session persistence issues.

- Fixes: #417

### Checklist
- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [ ] Added unit tests, if applicable
- [x] Verified all tests pass
- [x] Updated documentation, if needed

### Additional Notes

Without ENV=production, session cookies had Secure=false, causing browsers to reject them on HTTPS sites. This resulted in users having to log in on every visit.

Changes:
- Added ENV variable to backend-env-configmap.yaml
- Added ENV reference to backend-deployment.yaml  
- Updated production README with ENV configuration
