### PR TITLE
fix(Tasks): implement hotkeysEnabled state to control keyboard shortcuts

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -11,7 +11,10 @@ module.exports = {
   transformIgnorePatterns: ['/node_modules/(?!react-toastify)'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
-  testMatch: ['**/__tests__/**/*.{ts,tsx}', '**/?(*.)+(spec|test).{ts,tsx}'],
+  testMatch: [
+    '**/__tests__/**/*.+(test|spec).{ts,tsx}',
+    '**/?(*.)+(spec|test).{ts,tsx}',
+  ],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/Tasks.tsx
@@ -116,7 +116,9 @@ export const Tasks = (
   );
   const [autoSyncOnEdit, setAutoSyncOnEdit] = useState(true);
   const tableRef = useRef<HTMLDivElement>(null);
-  const [hotkeysEnabled, setHotkeysEnabled] = useState(false);
+  const [isMouseOver, setIsMouseOver] = useState(false);
+  const [activeContext, setActiveContext] = useState<string | null>(null);
+  const hotkeysEnabled = activeContext === 'TASKS' || isMouseOver;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const {
     state: editState,
@@ -152,7 +154,26 @@ export const Tasks = (
   const totalPages = Math.ceil(tempTasks.length / tasksPerPage) || 1;
 
   useEffect(() => {
+    const handleGlobalPointerDown = (e: PointerEvent) => {
+      if (tableRef.current && !tableRef.current.contains(e.target as Node)) {
+        setActiveContext(null);
+      }
+    };
+
+    document.addEventListener('pointerdown', handleGlobalPointerDown, true);
+    return () => {
+      document.removeEventListener(
+        'pointerdown',
+        handleGlobalPointerDown,
+        true
+      );
+    };
+  }, []);
+
+  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (!hotkeysEnabled) return;
+
       const target = e.target as HTMLElement;
       if (
         target instanceof HTMLInputElement ||
@@ -1022,83 +1043,115 @@ export const Tasks = (
     }
   };
 
-  useHotkeys(['f'], () => {
-    if (!showReports) {
-      document.getElementById('search')?.focus();
-    }
-  });
-  useHotkeys(['a'], () => {
-    if (!showReports) {
-      document.getElementById('add-new-task')?.click();
-    }
-  });
-  useHotkeys(['r'], () => {
-    if (!showReports) {
-      document.getElementById('sync-task')?.click();
-    }
-  });
-  useHotkeys(['p'], () => {
-    if (!showReports) {
-      document.getElementById('projects')?.click();
-    }
-  });
-  useHotkeys(['s'], () => {
-    if (!showReports) {
-      document.getElementById('status')?.click();
-    }
-  });
-  useHotkeys(['t'], () => {
-    if (!showReports) {
-      document.getElementById('tags')?.click();
-    }
-  });
-  useHotkeys(['c'], () => {
-    if (!showReports && !_isDialogOpen) {
-      const task = currentTasks[selectedIndex];
-      if (!task) return;
-      const openBtn = document.getElementById(`task-row-${task.id}`);
-      openBtn?.click();
-      setTimeout(() => {
-        const confirmBtn = document.getElementById(
-          `mark-task-complete-${task.id}`
-        );
-        confirmBtn?.click();
-      }, 200);
-    } else {
-      if (_isDialogOpen) {
+  useHotkeys(
+    ['f'],
+    () => {
+      if (!showReports) {
+        document.getElementById('search')?.focus();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['a'],
+    () => {
+      if (!showReports) {
+        document.getElementById('add-new-task')?.click();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['r'],
+    () => {
+      if (!showReports) {
+        document.getElementById('sync-task')?.click();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['p'],
+    () => {
+      if (!showReports) {
+        document.getElementById('projects')?.click();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['s'],
+    () => {
+      if (!showReports) {
+        document.getElementById('status')?.click();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['t'],
+    () => {
+      if (!showReports) {
+        document.getElementById('tags')?.click();
+      }
+    },
+    hotkeysEnabled
+  );
+  useHotkeys(
+    ['c'],
+    () => {
+      if (!showReports && !_isDialogOpen) {
         const task = currentTasks[selectedIndex];
         if (!task) return;
-        const confirmBtn = document.getElementById(
-          `mark-task-complete-${task.id}`
-        );
-        confirmBtn?.click();
+        const openBtn = document.getElementById(`task-row-${task.id}`);
+        openBtn?.click();
+        setTimeout(() => {
+          const confirmBtn = document.getElementById(
+            `mark-task-complete-${task.id}`
+          );
+          confirmBtn?.click();
+        }, 200);
+      } else {
+        if (_isDialogOpen) {
+          const task = currentTasks[selectedIndex];
+          if (!task) return;
+          const confirmBtn = document.getElementById(
+            `mark-task-complete-${task.id}`
+          );
+          confirmBtn?.click();
+        }
       }
-    }
-  });
+    },
+    hotkeysEnabled
+  );
 
-  useHotkeys(['d'], () => {
-    if (!showReports && !_isDialogOpen) {
-      const task = currentTasks[selectedIndex];
-      if (!task) return;
-      const openBtn = document.getElementById(`task-row-${task.id}`);
-      openBtn?.click();
-      setTimeout(() => {
-        const confirmBtn = document.getElementById(
-          `mark-task-as-deleted-${task.id}`
-        );
-        confirmBtn?.click();
-      }, 200);
-    } else {
-      if (_isDialogOpen) {
+  useHotkeys(
+    ['d'],
+    () => {
+      if (!showReports && !_isDialogOpen) {
         const task = currentTasks[selectedIndex];
         if (!task) return;
-        const confirmBtn = document.getElementById(
-          `mark-task-as-deleted-${task.id}`
-        );
-        confirmBtn?.click();
+        const openBtn = document.getElementById(`task-row-${task.id}`);
+        openBtn?.click();
+        setTimeout(() => {
+          const confirmBtn = document.getElementById(
+            `mark-task-as-deleted-${task.id}`
+          );
+          confirmBtn?.click();
+        }, 200);
+      } else {
+        if (_isDialogOpen) {
+          const task = currentTasks[selectedIndex];
+          if (!task) return;
+          const confirmBtn = document.getElementById(
+            `mark-task-as-deleted-${task.id}`
+          );
+          confirmBtn?.click();
+        }
       }
-    }
-  });
+    },
+    hotkeysEnabled
+  );
 
   return (
     <section
@@ -1159,8 +1212,10 @@ export const Tasks = (
       ) : (
         <div
           ref={tableRef}
-          onMouseEnter={() => setHotkeysEnabled(true)}
-          onMouseLeave={() => setHotkeysEnabled(false)}
+          data-testid="tasks-table-container"
+          onPointerDown={() => setActiveContext('TASKS')}
+          onMouseEnter={() => setIsMouseOver(true)}
+          onMouseLeave={() => setIsMouseOver(false)}
         >
           {tasks.length != 0 ? (
             <>

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/helper.ts
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/helper.ts
@@ -1,0 +1,6 @@
+import { screen, fireEvent } from '@testing-library/react';
+
+export const enableHotkeysViaHover = () => {
+  const taskContainer = screen.getByTestId('tasks-table-container');
+  fireEvent.mouseEnter(taskContainer);
+};

--- a/frontend/src/components/utils/__tests__/use-hotkeys.test.ts
+++ b/frontend/src/components/utils/__tests__/use-hotkeys.test.ts
@@ -216,4 +216,43 @@ describe('useHotkeys', () => {
 
     removeEventListenerSpy.mockRestore();
   });
+
+  it('should call callback when enabled is true', () => {
+    renderHook(() => useHotkeys(['s'], callback, true));
+
+    const event = new KeyboardEvent('keydown', {
+      key: 's',
+      bubbles: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call callback when enabled is false', () => {
+    renderHook(() => useHotkeys(['s'], callback, false));
+
+    const event = new KeyboardEvent('keydown', {
+      key: 's',
+      bubbles: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should default enabled to true when not provided', () => {
+    renderHook(() => useHotkeys(['s'], callback));
+
+    const event = new KeyboardEvent('keydown', {
+      key: 's',
+      bubbles: true,
+    });
+
+    window.dispatchEvent(event);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/components/utils/use-hotkeys.ts
+++ b/frontend/src/components/utils/use-hotkeys.ts
@@ -1,7 +1,13 @@
 import { useEffect } from 'react';
 
-export function useHotkeys(keys: string[], callback: () => void) {
+export function useHotkeys(
+  keys: string[],
+  callback: () => void,
+  enabled: boolean = true
+) {
   useEffect(() => {
+    if (!enabled) return;
+
     const handler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (
@@ -29,5 +35,5 @@ export function useHotkeys(keys: string[], callback: () => void) {
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [keys, callback]);
+  }, [keys, callback, enabled]);
 }


### PR DESCRIPTION
### Description

- Add `enabled` parameter to useHotkeys hook with default true value
- Pass hotkeysEnabled state to all useHotkeys calls in Tasks component
- Add hotkeysEnabled check in manual keyboard handler (ArrowUp/Down/Enter)
- Add data-testid to tasks table container for testing
- Add tests for useHotkeys enabled parameter
- Add tests for hotkeys enable/disable on mouse hover
- Add active context pattern with `onPointerDown` for tablet/touch support
- Add global pointerdown listener to disable hotkeys on outside click
- Add tests for active context scenarios

- Fixes: #425 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [ ] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Additional Notes

#### Video:

https://github.com/user-attachments/assets/1cbae957-8958-4566-947f-7716cf663ebe


