### PR TITLE
feat: auto-deploy to production after images are built

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,3 +69,28 @@ jobs:
             ghcr.io/ccextractor/backend:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    needs: [build-and-push-frontend, build-and-push-backend]
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ vars.SSH_HOST }}
+          username: ${{ vars.SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ vars.SSH_PORT }}
+          command_timeout: 10m
+          script: |
+            /opt/ccsync/scripts/deploy.sh ${{ github.sha }}
+
+      - name: Deployment summary
+        run: |
+          echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Server:** https://taskwarrior-server.ccextractor.org" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Makes deployment fully automatic by adding a `deploy` job to the Docker build workflow.

**Before:** Push to main → images built → manual trigger required to deploy
**After:** Push to main → images built → auto-deploy to production

## How It Works

```
push to main
    ↓
┌─────────────────────────────────────┐
│  build-and-push-frontend (parallel) │
│  build-and-push-backend  (parallel) │
└─────────────────────────────────────┘
    ↓ (both must succeed)
┌─────────────────────────────────────┐
│  deploy                             │
│  - SSH to VPS                       │
│  - Run deploy.sh with commit SHA    │
│  - Health check + auto-rollback     │
└─────────────────────────────────────┘
```

## Safety

- Deploy only runs if both build jobs succeed
- Uses commit SHA as image tag (immutable)
- deploy.sh has automatic rollback on health check failure
- GitHub environment protection can add required reviewers if needed

## Test plan

- [ ] Merge this PR
- [ ] Verify the deploy job runs automatically
- [ ] Check https://taskwarrior-server.ccextractor.org is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)