### PR TITLE
Refine Add Task dialog layout and advanced fields

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -62,7 +62,7 @@
 /* width */
 ::-webkit-scrollbar {
   height: 2px;
-  width: 10px;
+  width: 6px;
 }
 
 /* Track */

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -385,8 +385,36 @@ export const AddTaskdialog = ({
                         setNewTask({ ...newTask, tags })
                       }
                       placeholder="Select or create tags..."
+                      hideSelectedDisplay
                     />
                   </div>
+                  {newTask.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
+                      {newTask.tags.map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="h-auto py-2 px-3 text-sm bg-blue-500/10 text-blue-700 dark:text-blue-300 hover:bg-blue-500/20"
+                        >
+                          <TagIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                          <span className="max-w-[200px] truncate">{tag}</span>
+                          <button
+                            type="button"
+                            className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
+                            aria-label={`Remove tag ${tag}`}
+                            onClick={() =>
+                              setNewTask({
+                                ...newTask,
+                                tags: newTask.tags.filter((t) => t !== tag),
+                              })
+                            }
+                          >
+                            ✖
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </section>
 
@@ -422,32 +450,27 @@ export const AddTaskdialog = ({
                     />
                   </div>
                   {newTask.annotations.length > 0 && (
-                    <div className="space-y-2">
-                      <p className="text-sm text-muted-foreground">
-                        Added annotations:
-                      </p>
-                      <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
-                        {newTask.annotations.map((annotation, index) => (
-                          <Badge
-                            key={index}
-                            variant="secondary"
-                            className="h-auto py-2 px-3 text-sm bg-green-500/10 text-green-700 dark:text-green-300 hover:bg-green-500/20"
+                    <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
+                      {newTask.annotations.map((annotation, index) => (
+                        <Badge
+                          key={index}
+                          variant="secondary"
+                          className="h-auto py-2 px-3 text-sm bg-green-500/10 text-green-700 dark:text-green-300 hover:bg-green-500/20"
+                        >
+                          <FileText className="h-3 w-3 mr-1 flex-shrink-0" />
+                          <span className="max-w-[200px] truncate">
+                            {annotation.description}
+                          </span>
+                          <button
+                            type="button"
+                            className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
+                            aria-label="remove annotation"
+                            onClick={() => handleRemoveAnnotation(annotation)}
                           >
-                            <FileText className="h-3 w-3 mr-1 flex-shrink-0" />
-                            <span className="max-w-[200px] truncate">
-                              {annotation.description}
-                            </span>
-                            <button
-                              type="button"
-                              className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
-                              aria-label="remove annotation"
-                              onClick={() => handleRemoveAnnotation(annotation)}
-                            >
-                              ✖
-                            </button>
-                          </Badge>
-                        ))}
-                      </div>
+                            ✖
+                          </button>
+                        </Badge>
+                      ))}
                     </div>
                   )}
                 </div>
@@ -535,48 +558,43 @@ export const AddTaskdialog = ({
 
                   {/* Display selected dependencies */}
                   {newTask.depends.length > 0 && (
-                    <div className="space-y-2">
-                      <p className="text-sm text-muted-foreground">
-                        Selected dependencies:
-                      </p>
-                      <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
-                        {newTask.depends.map((taskUuid) => {
-                          const dependentTask = allTasks.find(
-                            (t) => t.uuid === taskUuid
-                          );
-                          return (
-                            <Badge
-                              key={taskUuid}
-                              variant="secondary"
-                              className="h-auto py-2 px-3 text-sm bg-purple-500/10 text-purple-700 dark:text-purple-300 hover:bg-purple-500/20"
+                    <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
+                      {newTask.depends.map((taskUuid) => {
+                        const dependentTask = allTasks.find(
+                          (t) => t.uuid === taskUuid
+                        );
+                        return (
+                          <Badge
+                            key={taskUuid}
+                            variant="secondary"
+                            className="h-auto py-2 px-3 text-sm bg-purple-500/10 text-purple-700 dark:text-purple-300 hover:bg-purple-500/20"
+                          >
+                            <Link2 className="h-3 w-3 mr-1 flex-shrink-0" />
+                            <span className="max-w-[200px] truncate">
+                              #{dependentTask?.id || '?'}{' '}
+                              {dependentTask?.description?.substring(0, 20) ||
+                                taskUuid.substring(0, 8)}
+                              {dependentTask?.description &&
+                                dependentTask.description.length > 20 &&
+                                '...'}
+                            </span>
+                            <button
+                              type="button"
+                              className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
+                              onClick={() => {
+                                setNewTask({
+                                  ...newTask,
+                                  depends: newTask.depends.filter(
+                                    (d) => d !== taskUuid
+                                  ),
+                                });
+                              }}
                             >
-                              <Link2 className="h-3 w-3 mr-1 flex-shrink-0" />
-                              <span className="max-w-[200px] truncate">
-                                #{dependentTask?.id || '?'}{' '}
-                                {dependentTask?.description?.substring(0, 20) ||
-                                  taskUuid.substring(0, 8)}
-                                {dependentTask?.description &&
-                                  dependentTask.description.length > 20 &&
-                                  '...'}
-                              </span>
-                              <button
-                                type="button"
-                                className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
-                                onClick={() => {
-                                  setNewTask({
-                                    ...newTask,
-                                    depends: newTask.depends.filter(
-                                      (d) => d !== taskUuid
-                                    ),
-                                  });
-                                }}
-                              >
-                                ✖
-                              </button>
-                            </Badge>
-                          );
-                        })}
-                      </div>
+                              ✖
+                            </button>
+                          </Badge>
+                        );
+                      })}
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { DateTimePicker } from '@/components/ui/date-time-picker';
 import {
   Dialog,
@@ -11,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Key } from '@/components/ui/key-button';
 import { Label } from '@/components/ui/label';
@@ -21,15 +23,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  AddFieldKey,
-  AddTaskDialogProps,
-  FieldKey,
-} from '@/components/utils/types';
+import { AddTaskDialogProps } from '@/components/utils/types';
 import { format } from 'date-fns';
-import { ADDTASKDIALOG_FIELDS } from './constants';
-import { useAddTaskDialogKeyboard } from './UseTaskDialogKeyboard';
-import { useAddTaskDialogFocusMap } from './UseTaskDialogFocusMap';
+import { Clock, Tag as TagIcon, FileText, Link2, Repeat } from 'lucide-react';
 import { MultiSelect } from './MultiSelect';
 
 export const AddTaskdialog = ({
@@ -49,59 +45,10 @@ export const AddTaskdialog = ({
   const [dependencySearch, setDependencySearch] = useState('');
   const [showDependencyResults, setShowDependencyResults] = useState(false);
 
-  const inputRefs = useRef<
-    Partial<
-      Record<
-        FieldKey,
-        HTMLInputElement | HTMLButtonElement | HTMLSelectElement | null
-      >
-    >
-  >({});
-  const [focusedFieldIndex, setFocusedFieldIndex] = useState(0);
-
-  const focusedField = ADDTASKDIALOG_FIELDS[focusedFieldIndex];
-
   const handleDialogOpenChange = (open: boolean) => {
     onOpenChange?.(open);
     setIsOpen(open);
   };
-
-  useEffect(() => {
-    const element = inputRefs.current[focusedField];
-    if (!element) return;
-
-    element.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-    });
-  }, [focusedField]);
-
-  const focusMap = useAddTaskDialogFocusMap({
-    fields: ADDTASKDIALOG_FIELDS,
-    inputRefs: inputRefs as any,
-  });
-
-  useEffect(() => {
-    focusMap(focusedField);
-  }, [focusedField, focusMap]);
-
-  const closeDialog = () => setIsOpen(false);
-
-  const onEnter = (field: AddFieldKey) => {
-    const element = inputRefs.current[field];
-    if (!element) return;
-
-    element.focus();
-    element.click();
-  };
-
-  const handleDialogKeyDown = useAddTaskDialogKeyboard({
-    fields: ADDTASKDIALOG_FIELDS,
-    focusedFieldIndex,
-    setFocusedFieldIndex,
-    onEnter,
-    closeDialog,
-  });
 
   const getFilteredTasks = () => {
     const availableTasks = allTasks.filter(
@@ -166,18 +113,16 @@ export const AddTaskdialog = ({
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogOpenChange}>
       <DialogTrigger asChild>
-        <Button
-          type="button"
-          id="add-new-task"
-          variant="outline"
-          onClick={() => setIsOpen(true)}
-        >
+        <Button type="button" id="add-new-task" variant="outline">
           Add Task
           <Key label="a" />
         </Button>
       </DialogTrigger>
-      <DialogContent tabIndex={0} onKeyDown={handleDialogKeyDown}>
-        <DialogHeader>
+      <DialogContent
+        tabIndex={0}
+        className="max-w-6xl max-h-[90vh] flex flex-col"
+      >
+        <DialogHeader className="flex-shrink-0">
           <DialogTitle>
             <span className="ml-0 mb-0 mr-0 text-2xl mt-0 md:text-2xl font-bold">
               <span className="inline bg-gradient-to-r from-[#F596D3]  to-[#D247BF] text-transparent bg-clip-text">
@@ -187,23 +132,24 @@ export const AddTaskdialog = ({
             </span>
           </DialogTitle>
           <DialogDescription>
-            Fill in the details below to add a new task.
+            Fill in the details below to add a new task
           </DialogDescription>
         </DialogHeader>
-        <div className="h-96 overflow-auto p-2">
-          <div className="flex flex-col items-start justify-start">
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'description' ? 'dark:bg-muted/50 bg-black/15' : ''}`}
-            >
-              <Label htmlFor="description" className="text-left col-span-1">
-                Description
-              </Label>
-              <div className="col-span-3">
+        <div className="overflow-y-auto space-y-6 py-4 px-2 flex-1 min-h-0">
+          {/* Essential Fields Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Essential Fields</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Description - Full Width */}
+              <div className="space-y-2">
+                <Label htmlFor="description">Description *</Label>
                 <Input
-                  ref={(element) => (inputRefs.current.description = element)}
                   id="description"
                   name="description"
                   type="text"
+                  placeholder="Task description..."
                   value={newTask.description}
                   onChange={(e) =>
                     setNewTask({
@@ -212,132 +158,109 @@ export const AddTaskdialog = ({
                     })
                   }
                   required
-                  className="col-span-6"
                 />
               </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'priority' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label
-                htmlFor="priority"
-                className="col-span-1 text-left w-[75px]"
-              >
-                Priority
-              </Label>
-              <div className="col-span-1 flex items-center">
-                <select
-                  ref={(element) => (inputRefs.current.priority = element)}
-                  id="priority"
-                  name="priority"
-                  value={newTask.priority}
-                  onChange={(e) =>
-                    setNewTask({
-                      ...newTask,
-                      priority: e.target.value,
-                    })
-                  }
-                  className="border rounded-md px-2 py-1 w-full bg-white text-black dark:bg-black dark:text-white transition-colors"
-                >
-                  <option value="H">H</option>
-                  <option value="M">M</option>
-                  <option value="L">L</option>
-                </select>
-              </div>
-            </div>
 
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'project' ? 'dark:bg-muted/50 bg-black/15' : ''}`}
-            >
-              <Label
-                htmlFor="project"
-                className="text-left col-span-1 w-[77px]"
-              >
-                Project
-              </Label>
-              <div className="col-span-3 space-y-2">
-                <Select
-                  value={
-                    isCreatingNewProject ? '__CREATE_NEW__' : newTask.project
-                  }
-                  onValueChange={(value) => {
-                    if (value === '__CREATE_NEW__') {
-                      setIsCreatingNewProject(true);
-                      setNewTask({ ...newTask, project: '' });
-                    } else if (value === '__NONE__') {
-                      setIsCreatingNewProject(false);
-                      setNewTask({ ...newTask, project: '' });
-                    } else {
-                      setIsCreatingNewProject(false);
-                      setNewTask({ ...newTask, project: value });
+              {/* Priority and Project - Two Column */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="priority">Priority</Label>
+                  <select
+                    id="priority"
+                    name="priority"
+                    value={newTask.priority}
+                    onChange={(e) =>
+                      setNewTask({
+                        ...newTask,
+                        priority: e.target.value,
+                      })
                     }
-                  }}
-                >
-                  <SelectTrigger
-                    onKeyDown={(e) => {
-                      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-                        e.preventDefault();
-                      }
-                      if (e.key === 'Enter') {
-                        (e.currentTarget as HTMLButtonElement).click();
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <option value="">Select priority</option>
+                    <option value="H">High</option>
+                    <option value="M">Medium</option>
+                    <option value="L">Low</option>
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="project">Project</Label>
+                  <Select
+                    value={
+                      isCreatingNewProject ? '__CREATE_NEW__' : newTask.project
+                    }
+                    onValueChange={(value) => {
+                      if (value === '__CREATE_NEW__') {
+                        setIsCreatingNewProject(true);
+                        setNewTask({ ...newTask, project: '' });
+                      } else if (value === '__NONE__') {
+                        setIsCreatingNewProject(false);
+                        setNewTask({ ...newTask, project: '' });
+                      } else {
+                        setIsCreatingNewProject(false);
+                        setNewTask({ ...newTask, project: value });
                       }
                     }}
-                    ref={(element) => (inputRefs.current.project = element)}
-                    id="project"
-                    data-testid="project-select"
                   >
-                    <SelectValue
-                      placeholder={
-                        uniqueProjects.length
-                          ? 'Select a project'
-                          : 'No projects yet'
-                      }
+                    <SelectTrigger id="project" data-testid="project-select">
+                      <SelectValue
+                        placeholder={
+                          uniqueProjects.length
+                            ? 'Select a project'
+                            : 'No projects yet'
+                        }
+                      >
+                        {isCreatingNewProject
+                          ? newTask.project
+                            ? `New: ${newTask.project}`
+                            : '+ Create new project…'
+                          : undefined}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent
+                      onWheel={(e) => e.stopPropagation()}
+                      className="max-h-60 overflow-y-auto"
                     >
-                      {isCreatingNewProject
-                        ? newTask.project
-                          ? `New: ${newTask.project}`
-                          : '+ Create new project…'
-                        : undefined}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent
-                    onWheel={(e) => e.stopPropagation()}
-                    className="max-h-60 overflow-y-auto"
-                  >
-                    <SelectItem value="__CREATE_NEW__">
-                      + Create new project…
-                    </SelectItem>
-                    <SelectItem value="__NONE__">No project</SelectItem>
-                    {uniqueProjects.map((project: string) => (
-                      <SelectItem key={project} value={project}>
-                        {project}
+                      <SelectItem value="__CREATE_NEW__">
+                        + Create new project…
                       </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-
-                {isCreatingNewProject && (
-                  <Input
-                    id="project-name"
-                    placeholder="New project name"
-                    value={newTask.project}
-                    autoFocus
-                    onChange={(e) =>
-                      setNewTask({ ...newTask, project: e.target.value })
-                    }
-                  />
-                )}
+                      <SelectItem value="__NONE__">No project</SelectItem>
+                      {uniqueProjects.map((project: string) => (
+                        <SelectItem key={project} value={project}>
+                          {project}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {isCreatingNewProject && (
+                    <Input
+                      id="project-name"
+                      placeholder="New project name"
+                      value={newTask.project}
+                      autoFocus
+                      onChange={(e) =>
+                        setNewTask({ ...newTask, project: e.target.value })
+                      }
+                      className="mt-2"
+                    />
+                  )}
+                </div>
               </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'due' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="due" className="text-left w-[77px] col-span-1">
-                Due
-              </Label>
-              <div className="col-span-3">
+
+              {/* Due Date - Full Width */}
+              <div className="space-y-2">
+                <Label
+                  htmlFor="due"
+                  className="flex items-center gap-2 text-sm font-medium"
+                >
+                  Due Date
+                  <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-xs text-muted-foreground font-normal">
+                    (with time)
+                  </span>
+                </Label>
                 <DateTimePicker
-                  ref={(element) => (inputRefs.current.due = element)}
                   date={
                     newTask.due
                       ? new Date(
@@ -360,362 +283,370 @@ export const AddTaskdialog = ({
                   placeholder="Select due date and time"
                 />
               </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'start' ? 'dark:bg-muted/50 bg-black/15' : ''}`}
-            >
-              <Label htmlFor="start" className="text-left col-span-1 w-[77px]">
-                Start
-              </Label>
-              <div className="col-span-3">
-                <DateTimePicker
-                  ref={(element) => (inputRefs.current.start = element)}
-                  date={
-                    newTask.start
-                      ? new Date(
-                          newTask.start.includes('T')
-                            ? newTask.start
-                            : `${newTask.start}T00:00:00`
-                        )
-                      : undefined
-                  }
-                  onDateTimeChange={(date, hasTime) => {
-                    setNewTask({
-                      ...newTask,
-                      start: date
-                        ? hasTime
-                          ? date.toISOString()
-                          : format(date, 'yyyy-MM-dd')
-                        : '',
-                    });
-                  }}
-                  placeholder="Select start date and time"
-                />
-              </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'end' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="end" className="text-left col-span-1 w-[77px]">
-                End
-              </Label>
-              <div className="col-span-3">
-                <DateTimePicker
-                  ref={(element) => (inputRefs.current.end = element)}
-                  date={
-                    newTask.end
-                      ? new Date(
-                          newTask.end.includes('T')
-                            ? newTask.end
-                            : `${newTask.end}T00:00:00`
-                        )
-                      : undefined
-                  }
-                  onDateTimeChange={(date, hasTime) => {
-                    setNewTask({
-                      ...newTask,
-                      end: date
-                        ? hasTime
-                          ? date.toISOString()
-                          : format(date, 'yyyy-MM-dd')
-                        : '',
-                    });
-                  }}
-                  placeholder="Select end date and time"
-                />
-                {newTask.end && (
-                  <div className="mt-1.5 pl-2.5 border-l-2 border-amber-500/60">
-                    <p className="text-xs text-amber-400 leading-tight">
-                      Task will be marked as completed
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'entry' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="entry" className="text-left col-span-1 w-[77px]">
-                Entry
-              </Label>
-              <div className="col-span-3">
-                <DateTimePicker
-                  ref={(element) => (inputRefs.current.entry = element)}
-                  date={
-                    newTask.entry
-                      ? new Date(
-                          newTask.entry.includes('T')
-                            ? newTask.entry
-                            : `${newTask.entry}T00:00:00`
-                        )
-                      : undefined
-                  }
-                  onDateTimeChange={(date, hasTime) => {
-                    setNewTask({
-                      ...newTask,
-                      entry: date
-                        ? hasTime
-                          ? date.toISOString()
-                          : format(date, 'yyyy-MM-dd')
-                        : '',
-                    });
-                  }}
-                  placeholder="Select entry date and time"
-                />
-              </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'wait' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="wait" className="text-left col-span-1 w-[77px]">
-                Wait
-              </Label>
-              <div className="col-span-3">
-                <DateTimePicker
-                  ref={(element) => (inputRefs.current.wait = element)}
-                  date={
-                    newTask.wait
-                      ? new Date(
-                          newTask.wait.includes('T')
-                            ? newTask.wait
-                            : `${newTask.wait}T00:00:00`
-                        )
-                      : undefined
-                  }
-                  onDateTimeChange={(date, hasTime) => {
-                    setNewTask({
-                      ...newTask,
-                      wait: date
-                        ? hasTime
-                          ? date.toISOString()
-                          : format(date, 'yyyy-MM-dd')
-                        : '',
-                    });
-                  }}
-                  placeholder="Select wait date and time"
-                />
-              </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'recur' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="recur" className="text-left col-span-1 w-[77px]">
-                Recur
-              </Label>
-              <div className="col-span-3 flex items-start">
-                <select
-                  ref={(element) => (inputRefs.current.recur = element)}
-                  id="recur"
-                  name="recur"
-                  value={newTask.recur}
-                  onChange={(e) =>
-                    setNewTask({
-                      ...newTask,
-                      recur: e.target.value,
-                    })
-                  }
-                  className="border rounded-md px-2 py-1 w-full bg-white text-black dark:bg-black dark:text-white transition-colors"
-                >
-                  <option value="">None</option>
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                  <option value="monthly">Monthly</option>
-                  <option value="yearly">Yearly</option>
-                </select>
-              </div>
-            </div>
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'tags' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label htmlFor="tags" className="text-left col-span-1 w-[77px]">
-                Tags
-              </Label>
-              <div className="col-span-3">
-                <MultiSelect
-                  ref={(element) => (inputRefs.current.tags = element)}
-                  availableItems={uniqueTags}
-                  selectedItems={newTask.tags}
-                  onItemsChange={(tags: string[]) =>
-                    setNewTask({ ...newTask, tags })
-                  }
-                  placeholder="Select or create tags"
-                />
-              </div>
-            </div>
+            </CardContent>
+          </Card>
 
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'annotations' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label
-                htmlFor="annotations"
-                className="text-left col-span-1 w-[77px]"
-              >
-                Annotation
-              </Label>
-              <div className="col-span-3">
-                <Input
-                  ref={(element) => (inputRefs.current.annotations = element)}
-                  id="annotations"
-                  name="annotations"
-                  placeholder="Add an annotation"
-                  value={annotationInput}
-                  onChange={(e) => setAnnotationInput(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleAddAnnotation()}
-                  className="col-span-3"
-                />
-              </div>
-            </div>
+          {/* Dates Card */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Dates</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {/* Start Date */}
+                <div className="space-y-2">
+                  <Label htmlFor="start">Start Date</Label>
+                  <DatePicker
+                    date={newTask.start ? new Date(newTask.start) : undefined}
+                    onDateChange={(date) => {
+                      setNewTask({
+                        ...newTask,
+                        start: date ? format(date, 'yyyy-MM-dd') : '',
+                      });
+                    }}
+                    placeholder="Select start date"
+                  />
+                </div>
 
-            {newTask.annotations.length > 0 && (
-              <div className="grid grid-cols-4 items-center">
-                <div> </div>
-                <div className="flex flex-wrap gap-2 col-span-3">
-                  {newTask.annotations.map((annotation, index) => (
-                    <Badge key={index}>
-                      <span>{annotation.description}</span>
-                      <button
-                        type="button"
-                        className="ml-2 text-red-500"
-                        aria-label="remove annotation"
-                        onClick={() => handleRemoveAnnotation(annotation)}
-                      >
-                        ✖
-                      </button>
-                    </Badge>
-                  ))}
+                {/* End Date */}
+                <div className="space-y-2">
+                  <Label htmlFor="end">End Date</Label>
+                  <DatePicker
+                    date={newTask.end ? new Date(newTask.end) : undefined}
+                    onDateChange={(date) => {
+                      setNewTask({
+                        ...newTask,
+                        end: date ? format(date, 'yyyy-MM-dd') : '',
+                      });
+                    }}
+                    placeholder="Select end date"
+                  />
+                </div>
+
+                {/* Entry Date */}
+                <div className="space-y-2">
+                  <Label htmlFor="entry">Entry Date</Label>
+                  <DatePicker
+                    date={newTask.entry ? new Date(newTask.entry) : undefined}
+                    onDateChange={(date) => {
+                      setNewTask({
+                        ...newTask,
+                        entry: date ? format(date, 'yyyy-MM-dd') : '',
+                      });
+                    }}
+                    placeholder="Select entry date"
+                  />
+                </div>
+
+                {/* Wait Date */}
+                <div className="space-y-2">
+                  <Label htmlFor="wait">Wait Date</Label>
+                  <DatePicker
+                    date={newTask.wait ? new Date(newTask.wait) : undefined}
+                    onDateChange={(date) => {
+                      setNewTask({
+                        ...newTask,
+                        wait: date ? format(date, 'yyyy-MM-dd') : '',
+                      });
+                    }}
+                    placeholder="Select wait date"
+                  />
                 </div>
               </div>
-            )}
+            </CardContent>
+          </Card>
 
-            <div
-              className={`grid grid-cols-4 items-center gap-4 border-b py-6 px-2 w-full ${focusedField === 'depends' ? 'dark:bg-muted/50 bg-black/15' : ''} `}
-            >
-              <Label
-                htmlFor="depends"
-                className="text-left col-span-1 w-[87px]"
-              >
-                Depends On
-              </Label>
-              <div className="col-span-3 space-y-2 relative">
-                {/* Search input */}
-                <Input
-                  ref={(element) => (inputRefs.current.depends = element)}
-                  placeholder="Search and select tasks this depends on..."
-                  value={dependencySearch}
-                  onChange={(e) => {
-                    setDependencySearch(e.target.value);
-                    setShowDependencyResults(e.target.value.trim() !== '');
-                  }}
-                  onFocus={() =>
-                    setShowDependencyResults(dependencySearch.trim() !== '')
-                  }
-                />
-
-                {/* Search results dropdown */}
-                {showDependencyResults && (
-                  <div className="absolute z-50 w-full mt-1 bg-background border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
-                    {(() => {
-                      const filteredTasks = getFilteredTasks();
-
-                      if (filteredTasks.length === 0) {
-                        return (
-                          <div className="p-3 text-sm text-muted-foreground text-center">
-                            No tasks found matching your search
-                          </div>
-                        );
+          {/* Advanced Fields */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Advanced Fields</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Tags */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <TagIcon className="h-4 w-4 text-blue-500" />
+                  <span className="font-semibold text-sm">Tags</span>
+                  {newTask.tags.length > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="ml-2 h-5 px-2 text-xs"
+                    >
+                      {newTask.tags.length}
+                    </Badge>
+                  )}
+                </div>
+                <div className="space-y-3">
+                  <div className="p-4 bg-muted/30 rounded-lg border border-dashed">
+                    <MultiSelect
+                      availableItems={uniqueTags}
+                      selectedItems={newTask.tags}
+                      onItemsChange={(tags: string[]) =>
+                        setNewTask({ ...newTask, tags })
                       }
-
-                      return filteredTasks.map((task) => (
-                        <div
-                          key={task.uuid}
-                          className="p-3 cursor-pointer hover:bg-accent transition-colors"
-                          onMouseDown={(e) => {
-                            e.preventDefault(); // prevents blur
-                            setNewTask({
-                              ...newTask,
-                              depends: [...newTask.depends, task.uuid],
-                            });
-                            setDependencySearch('');
-                            setShowDependencyResults(false);
-                          }}
-                        >
-                          <div className="flex items-center gap-2 w-full min-w-0">
-                            <span className="font-medium text-xs shrink-0 text-muted-foreground">
-                              #{task.id}
-                            </span>
-                            <span className="truncate flex-1 text-sm">
-                              {task.description}
-                            </span>
-                            {task.project && (
-                              <Badge
-                                variant="secondary"
-                                className="text-xs px-1 py-0 shrink-0"
-                              >
-                                {task.project}
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                      ));
-                    })()}
+                      placeholder="Select or create tags..."
+                    />
                   </div>
-                )}
+                </div>
+              </section>
 
-                {/* Display selected dependencies */}
-                {newTask.depends.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {newTask.depends.map((taskUuid) => {
-                      const dependentTask = allTasks.find(
-                        (t) => t.uuid === taskUuid
-                      );
-                      return (
-                        <Badge
-                          key={taskUuid}
-                          variant="secondary"
-                          className="flex items-center gap-1"
-                        >
-                          <span>
-                            #{dependentTask?.id || '?'}{' '}
-                            {dependentTask?.description?.substring(0, 20) ||
-                              taskUuid.substring(0, 8)}
-                            {dependentTask?.description &&
-                              dependentTask.description.length > 20 &&
-                              '...'}
-                          </span>
-                          <button
-                            type="button"
-                            className="ml-1 text-red-500 hover:text-red-700"
-                            onClick={() => {
+              {/* Annotations */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <FileText className="h-4 w-4 text-green-500" />
+                  <span className="font-semibold text-sm">Annotations</span>
+                  {newTask.annotations.length > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="ml-2 h-5 px-2 text-xs"
+                    >
+                      {newTask.annotations.length}
+                    </Badge>
+                  )}
+                </div>
+                <div className="space-y-3">
+                  <div className="p-4 bg-muted/30 rounded-lg border border-dashed">
+                    <Input
+                      id="annotations"
+                      name="annotations"
+                      placeholder="Add an annotation (press Enter to add)"
+                      value={annotationInput}
+                      onChange={(e) => setAnnotationInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleAddAnnotation();
+                        }
+                      }}
+                      className="h-10"
+                    />
+                  </div>
+                  {newTask.annotations.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm text-muted-foreground">
+                        Added annotations:
+                      </p>
+                      <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
+                        {newTask.annotations.map((annotation, index) => (
+                          <Badge
+                            key={index}
+                            variant="secondary"
+                            className="h-auto py-2 px-3 text-sm bg-green-500/10 text-green-700 dark:text-green-300 hover:bg-green-500/20"
+                          >
+                            <FileText className="h-3 w-3 mr-1 flex-shrink-0" />
+                            <span className="max-w-[200px] truncate">
+                              {annotation.description}
+                            </span>
+                            <button
+                              type="button"
+                              className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
+                              aria-label="remove annotation"
+                              onClick={() => handleRemoveAnnotation(annotation)}
+                            >
+                              ✖
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              {/* Dependencies */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Link2 className="h-4 w-4 text-purple-500" />
+                  <span className="font-semibold text-sm">Dependencies</span>
+                  {newTask.depends.length > 0 && (
+                    <Badge
+                      variant="secondary"
+                      className="ml-2 h-5 px-2 text-xs"
+                    >
+                      {newTask.depends.length}
+                    </Badge>
+                  )}
+                </div>
+                <div className="space-y-3 relative">
+                  <div className="p-4 bg-muted/30 rounded-lg border border-dashed">
+                    <Input
+                      placeholder="Search and select tasks this depends on..."
+                      value={dependencySearch}
+                      onChange={(e) => {
+                        setDependencySearch(e.target.value);
+                        setShowDependencyResults(e.target.value.trim() !== '');
+                      }}
+                      onFocus={() =>
+                        setShowDependencyResults(dependencySearch.trim() !== '')
+                      }
+                      className="h-10"
+                    />
+                  </div>
+
+                  {/* Search results dropdown */}
+                  {showDependencyResults && (
+                    <div className="absolute z-50 w-full mt-1 bg-background border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
+                      {(() => {
+                        const filteredTasks = getFilteredTasks();
+
+                        if (filteredTasks.length === 0) {
+                          return (
+                            <div className="p-3 text-sm text-muted-foreground text-center">
+                              No tasks found matching your search
+                            </div>
+                          );
+                        }
+
+                        return filteredTasks.map((task) => (
+                          <div
+                            key={task.uuid}
+                            className="p-3 cursor-pointer hover:bg-accent transition-colors"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
                               setNewTask({
                                 ...newTask,
-                                depends: newTask.depends.filter(
-                                  (d) => d !== taskUuid
-                                ),
+                                depends: [...newTask.depends, task.uuid],
                               });
+                              setDependencySearch('');
+                              setShowDependencyResults(false);
                             }}
                           >
-                            ✖
-                          </button>
-                        </Badge>
-                      );
-                    })}
+                            <div className="flex items-center gap-2 w-full min-w-0">
+                              <span className="font-medium text-xs shrink-0 text-muted-foreground">
+                                #{task.id}
+                              </span>
+                              <span className="truncate flex-1 text-sm">
+                                {task.description}
+                              </span>
+                              {task.project && (
+                                <Badge
+                                  variant="secondary"
+                                  className="text-xs px-1 py-0 shrink-0"
+                                >
+                                  {task.project}
+                                </Badge>
+                              )}
+                            </div>
+                          </div>
+                        ));
+                      })()}
+                    </div>
+                  )}
+
+                  {/* Display selected dependencies */}
+                  {newTask.depends.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm text-muted-foreground">
+                        Selected dependencies:
+                      </p>
+                      <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
+                        {newTask.depends.map((taskUuid) => {
+                          const dependentTask = allTasks.find(
+                            (t) => t.uuid === taskUuid
+                          );
+                          return (
+                            <Badge
+                              key={taskUuid}
+                              variant="secondary"
+                              className="h-auto py-2 px-3 text-sm bg-purple-500/10 text-purple-700 dark:text-purple-300 hover:bg-purple-500/20"
+                            >
+                              <Link2 className="h-3 w-3 mr-1 flex-shrink-0" />
+                              <span className="max-w-[200px] truncate">
+                                #{dependentTask?.id || '?'}{' '}
+                                {dependentTask?.description?.substring(0, 20) ||
+                                  taskUuid.substring(0, 8)}
+                                {dependentTask?.description &&
+                                  dependentTask.description.length > 20 &&
+                                  '...'}
+                              </span>
+                              <button
+                                type="button"
+                                className="ml-2 text-red-500 hover:text-red-700 flex-shrink-0"
+                                onClick={() => {
+                                  setNewTask({
+                                    ...newTask,
+                                    depends: newTask.depends.filter(
+                                      (d) => d !== taskUuid
+                                    ),
+                                  });
+                                }}
+                              >
+                                ✖
+                              </button>
+                            </Badge>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              {/* Recurrence */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Repeat className="h-4 w-4 text-orange-500" />
+                  <span className="font-semibold text-sm">Recurrence</span>
+                  {newTask.recur && (
+                    <Badge
+                      variant="secondary"
+                      className="ml-2 h-5 px-2 text-xs capitalize"
+                    >
+                      {newTask.recur}
+                    </Badge>
+                  )}
+                </div>
+                <div className="space-y-3">
+                  <div className="p-4 bg-muted/30 rounded-lg border border-dashed">
+                    <select
+                      id="recur"
+                      name="recur"
+                      value={newTask.recur}
+                      onChange={(e) =>
+                        setNewTask({
+                          ...newTask,
+                          recur: e.target.value,
+                        })
+                      }
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                      <option value="">None</option>
+                      <option value="daily">Daily</option>
+                      <option value="weekly">Weekly</option>
+                      <option value="monthly">Monthly</option>
+                      <option value="yearly">Yearly</option>
+                    </select>
                   </div>
-                )}
-              </div>
-            </div>
-          </div>
+                  {newTask.recur && (
+                    <div className="p-3 bg-orange-500/10 rounded-lg border border-orange-500/20">
+                      <div className="flex items-center gap-2 text-sm text-orange-700 dark:text-orange-300">
+                        <Repeat className="h-4 w-4" />
+                        <span>
+                          This task will repeat{' '}
+                          <strong className="capitalize">
+                            {newTask.recur}
+                          </strong>
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </section>
+            </CardContent>
+          </Card>
         </div>
-        <DialogFooter>
+        <DialogFooter className="flex-shrink-0 mt-4">
           <Button
-            className="dark:bg-white/5 bg-black hover:bg-black text-white"
-            variant="secondary"
-            onClick={() => setIsOpen(false)}
+            variant="outline"
+            onClick={() => {
+              setIsOpen(false);
+              onOpenChange?.(false);
+            }}
           >
             Cancel
           </Button>
           <Button
-            className="mb-1"
-            variant="default"
+            className="bg-gradient-to-r from-[#F596D3] to-[#D247BF] hover:from-[#F596D3] hover:to-[#D247BF] text-white"
             onClick={() => {
               onSubmit(newTask);
             }}

--- a/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/AddTaskDialog.tsx
@@ -136,13 +136,11 @@ export const AddTaskdialog = ({
           </DialogDescription>
         </DialogHeader>
         <div className="overflow-y-auto space-y-6 py-4 px-2 flex-1 min-h-0">
-          {/* Essential Fields Card */}
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Essential Fields</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              {/* Description - Full Width */}
               <div className="space-y-2">
                 <Label htmlFor="description">Description *</Label>
                 <Input
@@ -161,7 +159,6 @@ export const AddTaskdialog = ({
                 />
               </div>
 
-              {/* Priority and Project - Two Column */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="priority">Priority</Label>
@@ -191,16 +188,14 @@ export const AddTaskdialog = ({
                       isCreatingNewProject ? '__CREATE_NEW__' : newTask.project
                     }
                     onValueChange={(value) => {
-                      if (value === '__CREATE_NEW__') {
-                        setIsCreatingNewProject(true);
-                        setNewTask({ ...newTask, project: '' });
-                      } else if (value === '__NONE__') {
-                        setIsCreatingNewProject(false);
-                        setNewTask({ ...newTask, project: '' });
-                      } else {
-                        setIsCreatingNewProject(false);
-                        setNewTask({ ...newTask, project: value });
-                      }
+                      setIsCreatingNewProject(value === '__CREATE_NEW__');
+                      setNewTask({
+                        ...newTask,
+                        project:
+                          value === '__CREATE_NEW__' || value === '__NONE__'
+                            ? ''
+                            : value,
+                      });
                     }}
                   >
                     <SelectTrigger id="project" data-testid="project-select">
@@ -248,7 +243,6 @@ export const AddTaskdialog = ({
                 </div>
               </div>
 
-              {/* Due Date - Full Width */}
               <div className="space-y-2">
                 <Label
                   htmlFor="due"
@@ -286,14 +280,12 @@ export const AddTaskdialog = ({
             </CardContent>
           </Card>
 
-          {/* Dates Card */}
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Dates</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Start Date */}
                 <div className="space-y-2">
                   <Label htmlFor="start">Start Date</Label>
                   <DatePicker
@@ -308,7 +300,6 @@ export const AddTaskdialog = ({
                   />
                 </div>
 
-                {/* End Date */}
                 <div className="space-y-2">
                   <Label htmlFor="end">End Date</Label>
                   <DatePicker
@@ -323,7 +314,6 @@ export const AddTaskdialog = ({
                   />
                 </div>
 
-                {/* Entry Date */}
                 <div className="space-y-2">
                   <Label htmlFor="entry">Entry Date</Label>
                   <DatePicker
@@ -338,7 +328,6 @@ export const AddTaskdialog = ({
                   />
                 </div>
 
-                {/* Wait Date */}
                 <div className="space-y-2">
                   <Label htmlFor="wait">Wait Date</Label>
                   <DatePicker
@@ -356,13 +345,11 @@ export const AddTaskdialog = ({
             </CardContent>
           </Card>
 
-          {/* Advanced Fields */}
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Advanced Fields</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
-              {/* Tags */}
               <section className="space-y-3">
                 <div className="flex items-center gap-2">
                   <TagIcon className="h-4 w-4 text-blue-500" />
@@ -418,7 +405,6 @@ export const AddTaskdialog = ({
                 </div>
               </section>
 
-              {/* Annotations */}
               <section className="space-y-3">
                 <div className="flex items-center gap-2">
                   <FileText className="h-4 w-4 text-green-500" />
@@ -476,7 +462,6 @@ export const AddTaskdialog = ({
                 </div>
               </section>
 
-              {/* Dependencies */}
               <section className="space-y-3">
                 <div className="flex items-center gap-2">
                   <Link2 className="h-4 w-4 text-purple-500" />
@@ -506,7 +491,6 @@ export const AddTaskdialog = ({
                     />
                   </div>
 
-                  {/* Search results dropdown */}
                   {showDependencyResults && (
                     <div className="absolute z-50 w-full mt-1 bg-background border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
                       {(() => {
@@ -556,7 +540,6 @@ export const AddTaskdialog = ({
                     </div>
                   )}
 
-                  {/* Display selected dependencies */}
                   {newTask.depends.length > 0 && (
                     <div className="flex flex-wrap gap-2 p-3 bg-background rounded-lg border min-h-[60px]">
                       {newTask.depends.map((taskUuid) => {
@@ -600,7 +583,6 @@ export const AddTaskdialog = ({
                 </div>
               </section>
 
-              {/* Recurrence */}
               <section className="space-y-3">
                 <div className="flex items-center gap-2">
                   <Repeat className="h-4 w-4 text-orange-500" />

--- a/frontend/src/components/HomeComponents/Tasks/MultiSelect.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/MultiSelect.tsx
@@ -21,6 +21,7 @@ export const MultiSelect = React.forwardRef<
       showActions = false,
       onSave,
       onCancel,
+      hideSelectedDisplay = false,
     },
     ref
   ) => {
@@ -115,7 +116,7 @@ export const MultiSelect = React.forwardRef<
           <ChevronDown className="h-4 w-4 opacity-50" />
         </Button>
 
-        {selectedItems.length > 0 && (
+        {selectedItems.length > 0 && !hideSelectedDisplay && (
           <div className="flex flex-wrap items-center gap-2 mt-2">
             {selectedItems.map((item) => (
               <Badge key={item} className="flex items-center gap-1">

--- a/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
+++ b/frontend/src/components/HomeComponents/Tasks/__tests__/Tasks.test.tsx
@@ -987,7 +987,7 @@ describe('Tasks Component', () => {
         screen.getByText(/fill in the details below/i)
       ).toBeInTheDocument();
 
-      expect(screen.getByText('Depends On')).toBeInTheDocument();
+      expect(screen.getByText('Dependencies')).toBeInTheDocument();
     });
 
     test('dependency dropdown is available in add task dialog', async () => {
@@ -1000,7 +1000,11 @@ describe('Tasks Component', () => {
       const addTaskButton = screen.getByRole('button', { name: /add task/i });
       fireEvent.click(addTaskButton);
 
-      expect(screen.getByText('Depends On')).toBeInTheDocument();
+      // Ensure the Dependencies section and its search input are present
+      const dependenciesSection = screen
+        .getByText('Dependencies')
+        .closest('section') as HTMLElement;
+      expect(dependenciesSection).toBeInTheDocument();
       expect(
         screen.getByPlaceholderText(
           'Search and select tasks this depends on...'

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -141,6 +141,8 @@ export interface MultiSelectProps {
   showActions?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
+  /** When true, selected items are not shown inside the MultiSelect (e.g. when rendered elsewhere). */
+  hideSelectedDisplay?: boolean;
 }
 
 export interface EditTaskDialogProps {

--- a/frontend/src/components/utils/types.ts
+++ b/frontend/src/components/utils/types.ts
@@ -141,7 +141,6 @@ export interface MultiSelectProps {
   showActions?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
-  /** When true, selected items are not shown inside the MultiSelect (e.g. when rendered elsewhere). */
   hideSelectedDisplay?: boolean;
 }
 


### PR DESCRIPTION
### Description

Improve the Add Task dialog UX in the Tasks view by widening the dialog, grouping related fields into clearly labeled sections, and refreshing the styling of advanced fields. The new layout keeps all fields visible in a single scrollable panel (no accordion), uses Cards for “Essential Fields”, “Dates”, and “Advanced Fields”, and enhances tags/annotations/dependencies/recurrence with clearer visuals and counts.

- Fixes: #391 

### Checklist

- [x] Ran `npx prettier --write .` (for formatting)
- [x] Ran `gofmt -w .` (for Go backend)
- [x] Ran `npm test` (for JS/TS testing)
- [x] Added unit tests, if applicable
- [x] Verified all tests pass
- [ ] Updated documentation, if needed

### Screenshot

#### Light Mode
<img width="1871" height="959" alt="Screenshot from 2026-02-03 15-54-24" src="https://github.com/user-attachments/assets/a90e4b4b-fb5a-4c3e-8f1b-1258f7c42e20" />

#### Dark Mode
<img width="1855" height="961" alt="image" src="https://github.com/user-attachments/assets/7bda1e0b-5174-4df4-ae64-59eba4498a05" />

#### Mobile View
<img width="431" height="889" alt="image" src="https://github.com/user-attachments/assets/e212f777-48cd-43c0-8445-2855a639c255" />



### Additional Notes

- Due date now uses a DateTime picker with a clock indicator (“with time”) for clarity.
- Dialog uses a fixed header/footer with a scrollable middle section to keep actions always visible.
- Tags, annotations, dependencies, and recurrence are visually grouped in an “Advanced Fields” card with icons, color accents, and minimum heights to avoid cramped layouts.