### PR TITLE
fix(tw): Fix double date formatting and always-true annotation condition in edit_task.go

### DIFF
--- a/backend/utils/tw/edit_task.go
+++ b/backend/utils/tw/edit_task.go
@@ -40,7 +40,10 @@ func EditTaskInTaskwarrior(
 	}
 
 	if wait != "" {
-		formattedWait := wait + "T00:00:00"
+		formattedWait := wait
+		if !strings.Contains(wait, "T") {
+			formattedWait = wait + "T00:00:00"
+		}
 		modifyArgs = append(modifyArgs, "wait:"+formattedWait)
 	}
 
@@ -60,7 +63,10 @@ func EditTaskInTaskwarrior(
 	modifyArgs = append(modifyArgs, "depends:"+dependsStr)
 
 	if due != "" {
-		formattedDue := due + "T00:00:00"
+		formattedDue := due
+		if !strings.Contains(due, "T") {
+			formattedDue = due + "T00:00:00"
+		}
 		modifyArgs = append(modifyArgs, "due:"+formattedDue)
 	}
 
@@ -82,7 +88,7 @@ func EditTaskInTaskwarrior(
 		return fmt.Errorf("failed to edit task: %v", err)
 	}
 
-	if len(annotations) >= 0 {
+	if len(annotations) > 0 {
 		output, err := utils.ExecCommandForOutputInDir(tempDir, "task", taskUUID, "export")
 		if err == nil {
 			var tasks []map[string]interface{}


### PR DESCRIPTION
Fixes #464 

## Summary

This PR addresses two critical bugs in the `EditTaskInTaskwarrior` function within `backend/utils/tw/edit_task.go`:

1. **Double Date Formatting Produces Invalid Datetimes**  
   - Previously, `T00:00:00` was appended to all `wait` and `due` fields, even when they were already full ISO datetime strings. This resulted in invalid datetime strings like `2026-01-28T14:30:00T00:00:00`, which Taskwarrior rejected.
   - The fix ensures that `T00:00:00` is only appended to date-only strings (e.g., `2026-01-28`), leaving full datetime strings unchanged.

2. **Redundant Annotation Block Always Executes**  
   - The condition `len(annotations) >= 0` was always true, causing the annotation export → denotate → re-annotate block to execute unnecessarily, even when no annotations were provided. This led to redundant operations and unnecessary deletion/recreation of existing annotations.
   - The condition has been updated to `len(annotations) > 0` to ensure the block only executes when annotations are provided.

---

## Changes Made

### Bug 1: Double Date Formatting
- Updated the logic for `wait` and `due` fields:
  - Check if the string already contains `T` (indicating a full datetime).
  - Only append `T00:00:00` if the string is a date-only value.

### Bug 2: Redundant Annotation Block
- Changed the condition from `len(annotations) >= 0` to `len(annotations) > 0`.

---

## Files Changed
- `backend/utils/tw/edit_task.go`

---

## Testing

### Steps to Verify
1. **Double Date Formatting:**
   - Edit a task with a full ISO `due`/`wait` datetime (e.g., `2026-01-28T14:30:00`) and verify that Taskwarrior receives the unmodified string.
   - Edit a task with a date-only `due`/`wait` (e.g., `2026-01-28`) and verify that `T00:00:00` is appended.

2. **Annotation Block Execution:**
   - Edit a task without annotations and verify that existing annotations are not touched.
   - Edit a task with new annotations and verify that existing annotations are replaced correctly.

---

## Commit Message
