### PR TITLE
[FIX] Redirect logged-in users from / to /home

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -82,13 +82,7 @@ func main() {
 	store := sessions.NewCookieStore(sessionKey)
 
 	// Configure secure cookie options
-	store.Options = &sessions.Options{
-		Path:     "/",
-		MaxAge:   86400 * 7,                        // 7 days
-		HttpOnly: true,                             // Prevent JavaScript access
-		Secure:   os.Getenv("ENV") == "production", // HTTPS only in production
-		SameSite: http.SameSiteLaxMode,             // CSRF protection (Lax allows OAuth redirects)
-	}
+	store.Options = sessionCookieOptions()
 
 	gob.Register(map[string]interface{}{})
 

--- a/backend/session_options.go
+++ b/backend/session_options.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gorilla/sessions"
+)
+
+func sessionCookieOptions() *sessions.Options {
+	return &sessions.Options{
+		Path:     "/",
+		MaxAge:   86400 * 7,                        // 7 days
+		HttpOnly: true,                             // Prevent JavaScript access
+		Secure:   os.Getenv("ENV") == "production", // HTTPS only in production
+		SameSite: http.SameSiteLaxMode,             // CSRF protection (Lax allows OAuth redirects)
+	}
+}

--- a/backend/session_options_test.go
+++ b/backend/session_options_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionCookieOptions_Production(t *testing.T) {
+	t.Setenv("ENV", "production")
+
+	opts := sessionCookieOptions()
+
+	assert.Equal(t, "/", opts.Path)
+	assert.Equal(t, 86400*7, opts.MaxAge)
+	assert.True(t, opts.HttpOnly)
+	assert.True(t, opts.Secure)
+	assert.Equal(t, http.SameSiteLaxMode, opts.SameSite)
+}
+
+func TestSessionCookieOptions_NonProduction(t *testing.T) {
+	t.Setenv("ENV", "development")
+
+	opts := sessionCookieOptions()
+
+	assert.Equal(t, 86400*7, opts.MaxAge)
+	assert.True(t, opts.HttpOnly)
+	assert.False(t, opts.Secure)
+}
+
+func TestSessionCookieOptions_UnsetENV(t *testing.T) {
+	t.Setenv("ENV", "")
+
+	opts := sessionCookieOptions()
+
+	assert.Equal(t, 86400*7, opts.MaxAge)
+	assert.False(t, opts.Secure)
+}

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { url } from '@/components/utils/URLs';
 import { About } from './LandingComponents/About/About';
 import { FAQ } from './LandingComponents/FAQ/FAQ';
 import { Footer } from './LandingComponents/Footer/Footer';
@@ -9,6 +12,26 @@ import { Contact } from './LandingComponents/Contact/Contact';
 import '../App.css';
 
 export const LandingPage = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const redirectIfLoggedIn = async () => {
+      try {
+        const response = await fetch(url.backendURL + 'api/user', {
+          method: 'GET',
+          credentials: 'include',
+        });
+        if (response.ok) {
+          navigate('/home');
+        }
+      } catch (error) {
+        console.error('Error checking login status:', error);
+      }
+    };
+
+    redirectIfLoggedIn();
+  }, [navigate]);
+
   return (
     <div className="overflow-x-hidden">
       <Navbar />

--- a/frontend/src/components/__tests__/LandingPage.test.tsx
+++ b/frontend/src/components/__tests__/LandingPage.test.tsx
@@ -1,5 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { LandingPage } from '../LandingPage';
+
+const mockedNavigate = jest.fn();
+const consoleErrorSpy = jest
+  .spyOn(console, 'error')
+  .mockImplementation(() => {});
 
 // Mock dependencies
 jest.mock('../LandingComponents/Navbar/Navbar', () => ({
@@ -27,7 +32,28 @@ jest.mock('../../components/utils/ScrollToTop', () => ({
   ScrollToTop: () => <div>Mocked ScrollToTop</div>,
 }));
 
+jest.mock('react-router', () => ({
+  useNavigate: () => mockedNavigate,
+}));
+
+jest.mock('@/components/utils/URLs', () => ({
+  url: {
+    backendURL: 'http://mocked-backend-url/',
+  },
+}));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: false,
+  })
+) as jest.Mock;
+
 describe('LandingPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy.mockClear();
+  });
+
   it('renders all components correctly', () => {
     render(<LandingPage />);
 
@@ -39,6 +65,45 @@ describe('LandingPage', () => {
     expect(screen.getByText('Mocked FAQ')).toBeInTheDocument();
     expect(screen.getByText('Mocked Footer')).toBeInTheDocument();
     expect(screen.getByText('Mocked ScrollToTop')).toBeInTheDocument();
+  });
+
+  it('redirects to /home when the user is already logged in', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+    });
+
+    render(<LandingPage />);
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith('/home');
+    });
+    expect(fetch).toHaveBeenCalledWith('http://mocked-backend-url/api/user', {
+      method: 'GET',
+      credentials: 'include',
+    });
+  });
+
+  it('stays on the landing page when the user is not logged in', async () => {
+    render(<LandingPage />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('http://mocked-backend-url/api/user', {
+        method: 'GET',
+        credentials: 'include',
+      });
+    });
+    expect(mockedNavigate).not.toHaveBeenCalled();
+  });
+
+  it('stays on the landing page when the session check fails', async () => {
+    (fetch as jest.Mock).mockRejectedValueOnce(new Error('network error'));
+
+    render(<LandingPage />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+    expect(mockedNavigate).not.toHaveBeenCalled();
   });
 });
 

--- a/production/backend-deployment.yaml
+++ b/production/backend-deployment.yaml
@@ -40,6 +40,11 @@ spec:
                 configMapKeyRef:
                   key: CONTAINER_ORIGIN
                   name: backend-env
+            - name: ENV
+              valueFrom:
+                configMapKeyRef:
+                  key: ENV
+                  name: backend-env
             - name: FRONTEND_ORIGIN_DEV
               valueFrom:
                 configMapKeyRef:

--- a/production/backend-env-configmap.yaml
+++ b/production/backend-env-configmap.yaml
@@ -3,6 +3,7 @@ data:
   CLIENT_ID: "YOUR_GOOGLE_CLOUD_AUTH_CLIENT_ID" # Replace this in order to access the frontend
   CLIENT_SEC: "YOUR_GOOGLE_CLOUD_AUTH_CLIENT_SECRET" # Replace this in order to access the frontend
   CONTAINER_ORIGIN: http://syncserver:8080/
+  ENV: "production" # Required for secure HTTPS-only cookies
   FRONTEND_ORIGIN_DEV: http://localhost
   PORT: "8000"
   REDIRECT_URL_DEV: http://localhost:8000/auth/callback


### PR DESCRIPTION
### Description

When a user is already logged in, visiting `/` now checks `api/user` with `credentials: include` and redirects to `/home`. Kubernetes production now sets `ENV=production` so session cookies get the Secure flag (same leftover as #420). Session cookie options stay 7-day MaxAge and Secure only when `ENV=production`; those options are covered by unit tests. Auth middleware is unchanged.

This is a small PR from current main. It does not rewrite session helpers from #462.

- Fixes #417

**Not in this PR:** empty tasks in the UI while CLI sync works. That report is out of scope unless reproduced separately.

### Leftover from earlier PRs

- **#420** (Hell1213): K8s `ENV=production` only. Still missing on main. This PR includes that wiring (configmap + deployment). Docker already had `ENV=production`.
- **#462** (Vasist10): landing redirect + session/auth rewrite. Backend session (7-day MaxAge, Secure if `ENV=production`, AuthMiddleware) is already on main. LandingPage on main still had no logged-in redirect. Review asked for tests and questioned the auth middleware. This PR takes only the landing redirect + tests, not a second copy of the auth rewrite.

### Checklist

- [x] Ran `npx prettier --write` on the changed frontend files
- [ ] Ran `gofmt -w .` (Go was not available in a usable local install; CI will format/test)
- [x] Ran `npm test -- --testPathPattern=LandingPage`
- [x] Added unit tests (LandingPage fetch/router; session cookie Secure/MaxAge)
- [x] Verified LandingPage tests pass
- [ ] Updated documentation, if needed

### Additional Notes

A short verification video will be attached on this PR or on #417 (logged in, visit `/` → `/home`; refresh later still logged in).


https://github.com/user-attachments/assets/9285d015-68f5-45ac-91eb-1a056ed09eb3

